### PR TITLE
[WIP] Claire/cancancan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem 'jquery-rails'
 
 gem "paperclip", "~> 6.0.0"
 
+gem 'cancancan', '~> 1.10'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       sass (>= 3.3.4)
     builder (3.2.3)
     byebug (10.0.2)
+    cancancan (1.17.0)
     capybara (3.9.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -259,6 +260,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.3.7)
   byebug
+  cancancan (~> 1.10)
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
@@ -286,4 +288,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/app/assets/javascripts/helpers/api_routes.js
+++ b/app/assets/javascripts/helpers/api_routes.js
@@ -1,7 +1,6 @@
 class ApiRoutes {
   get works() {
     return {
-
       index: `/api/works`,
       create: `/api/works`,
       show: (id) => `/api/works/${id}`,

--- a/app/controllers/api/works_controller.rb
+++ b/app/controllers/api/works_controller.rb
@@ -1,11 +1,13 @@
 class Api::WorksController < ApplicationController
   respond_to :json
+
   def show
     @work = Work.find(params[:id])
     render json: @work
   end
 
   def create
+    authorize! :create, Work
     work_attr = work_params
     attachment_attr = work_attr.delete("attachments_attributes")
     @work = Work.new(work_attr)
@@ -22,12 +24,14 @@ class Api::WorksController < ApplicationController
 
   def update
     work = Work.find(params[:id])
+    authorize! :update, work
     new_work = work.update(params)
     render_json_message(:ok, message: 'Work successfully updated!')
   end
 
   def destroy
     work = Work.find(params[:id])
+    authorize! :delete, work
     if work.destroy
       render_json_message(:ok, message: 'Work successfully deleted')
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  def current_ability
+    if current_artist
+      @current_ability ||= Ability.new(current_artist)
+    else
+      @current_ability ||= Ability.new(current_buyer)
+    end
+  end
 end

--- a/app/controllers/works_controller.rb
+++ b/app/controllers/works_controller.rb
@@ -17,5 +17,11 @@ class WorksController < ApplicationController
   end
 
   def new
+    authorize! :create, Work
+  end
+
+  def edit
+    @work = Work.find(params[:id])
+    authorize! :update, @work
   end
 end

--- a/app/javascript/components/CreateWork.jsx
+++ b/app/javascript/components/CreateWork.jsx
@@ -39,7 +39,8 @@ class CreateWork extends React.Component {
     formData.append('work[material]', this.state.work.material);
     formData.append('work[medium]', this.state.work.medium);
     formData.append('work[availability]', this.state.work.availability);
-    formData.append('work[artist_id]', this.props.artist.id);
+    //formData.append('work[artist_id]', this.props.artist.id);
+    formData.append('work[artist_id]', 0);
 
     this.state.work.images.forEach((img) => {
       console.log(img);
@@ -54,7 +55,7 @@ class CreateWork extends React.Component {
         "X_CSRF-Token": document.getElementsByName("csrf-token")[0].content
       }
     }).then((data) => {
-      window.location = `/artists/` + this.props.artist.id;
+      //window.location = `/artists/` + this.props.artist.id;
     }).catch((data) => {
       console.error(data);
     });

--- a/app/javascript/components/CreateWork.jsx
+++ b/app/javascript/components/CreateWork.jsx
@@ -39,8 +39,7 @@ class CreateWork extends React.Component {
     formData.append('work[material]', this.state.work.material);
     formData.append('work[medium]', this.state.work.medium);
     formData.append('work[availability]', this.state.work.availability);
-    //formData.append('work[artist_id]', this.props.artist.id);
-    formData.append('work[artist_id]', 0);
+    formData.append('work[artist_id]', this.props.artist.id);
 
     this.state.work.images.forEach((img) => {
       console.log(img);
@@ -55,7 +54,7 @@ class CreateWork extends React.Component {
         "X_CSRF-Token": document.getElementsByName("csrf-token")[0].content
       }
     }).then((data) => {
-      //window.location = `/artists/` + this.props.artist.id;
+      window.location = `/artists/` + this.props.artist.id;
     }).catch((data) => {
       console.error(data);
     });

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,41 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+    user ||= Buyer.new
+    case user
+    when Artist
+      can :manage, Work, artist_id: user.id
+      can :read, Work
+      can :create, Work
+    when Buyer
+      can :read, Work
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,32 +2,6 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # Define abilities for the passed in user here. For example:
-    #
-    #   user ||= User.new # guest user (not logged in)
-    #   if user.admin?
-    #     can :manage, :all
-    #   else
-    #     can :read, :all
-    #   end
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, :published => true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
     user ||= Buyer.new
     case user
     when Artist

--- a/app/views/works/edit.html.slim
+++ b/app/views/works/edit.html.slim
@@ -1,0 +1,4 @@
+= render "partials/header"
+
+.container.dashboard-container
+  h1 editing this work! work id: #{@work.id}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   get '/works/' => 'works#index'
   get '/works/categories' => 'works#get_work_category_enums'
   get '/works/new' => 'works#new'
+  get '/works/edit/:id' => 'works#edit'
 
   get '/buyers/:id' => 'buyers#show', as: :buyerid
 


### PR DESCRIPTION
## Permissions for Viewing, Creating, Updating, and Deleting Works

- Implements CanCanCan gem
- Defines permissions for `Works` table and API
- Prevents a buyer from viewing the "edit work" and "create work" forms
- Prevents a buyer from accessing the create, update, and delete endpoints within the `API/works` controller
- Prevents an artist from accessing the update and delete endpoints within the `API/works` controller unless if the work belongs to them
- Sets up guest permissions to be a new pseudo-buyer account by default

More notes commented within PR. For now, given that the requests and transactions routes have not been merged, only applies permissions to the works routes.

### Migrations

Creates `Ability` model to manage user permissions.

### Tests Performed, Edge Cases

### Screenshots

![image](https://user-images.githubusercontent.com/29110579/48530580-24a94900-e84d-11e8-90de-aec0dd16fcf8.png)


CC: @clairelin135
