### PR TITLE
Claire/requests display

### DIFF
--- a/app/assets/javascripts/helpers/APIRoutes.js
+++ b/app/assets/javascripts/helpers/APIRoutes.js
@@ -20,6 +20,7 @@ class ApiRoutes {
       delete      : (id) => `/api/artists/destroy/${id}`,
       works       : (id) => `/api/artists/works/${id}`,
       requests    : (id) => `/api/artists/requests/${id}`,
+      commissions : (id) => `/api/artists/commissions/${id}`
     }
   }
 
@@ -41,7 +42,7 @@ class ApiRoutes {
   get commissions() {
     return {
       create: `/api/commissions`,
-      types: `/commissions/types`
+      types: `/commissions/types`,
     }
   }
 

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -44,6 +44,8 @@ input[type="checkbox"] {
   -moz-appearance: none;
   font-weight: 500;
   cursor: pointer;
+  box-sizing: border-box;
+  height: 44px;
 
   &:focus {
     outline: none;
@@ -109,4 +111,8 @@ input[type="checkbox"] {
   @extend .row-input;
   outline: none;
   @extend .pa2;
+}
+
+.pointer {
+  cursor: pointer;
 }

--- a/app/assets/stylesheets/components/snapshot.scss
+++ b/app/assets/stylesheets/components/snapshot.scss
@@ -1,0 +1,13 @@
+.snapshot {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  &:hover {
+    background-color: $snow;
+
+    h5 {
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/snapshot.scss
+++ b/app/assets/stylesheets/components/snapshot.scss
@@ -3,11 +3,8 @@
   flex-direction: row;
   align-items: center;
 
-  &:hover {
-    background-color: $snow;
-
-    h5 {
-      text-decoration: underline;
-    }
+  .snapshot-nav:hover {
+    @extend .pointer;
+    text-decoration: underline;
   }
 }

--- a/app/assets/stylesheets/pages/Request.scss
+++ b/app/assets/stylesheets/pages/Request.scss
@@ -41,7 +41,7 @@
 .request {
   display: flex;
   flex-direction: column;
-  border-top: 8px solid $mustard;
+  border-top: 8px solid $ochre;
 
   .request-header {
     display: flex;
@@ -76,4 +76,11 @@
 
 .toggle {
   cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.toggle-hover:hover {
+  background-color: $pale-gray;
 }

--- a/app/assets/stylesheets/pages/Request.scss
+++ b/app/assets/stylesheets/pages/Request.scss
@@ -1,20 +1,15 @@
-.content-row {
+.request-container {
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
 
-  .request-container {
+  .request-action {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     flex: 1;
-
-    .request-action {
-      flex: 1;
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-    }
+    justify-content: space-between;
+    align-items: center;
   }
 }
 
@@ -94,6 +89,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  padding: 12px 8px;
 }
 
 .toggle-hover:hover {

--- a/app/assets/stylesheets/pages/Request.scss
+++ b/app/assets/stylesheets/pages/Request.scss
@@ -3,16 +3,17 @@
   flex-direction: row;
   align-items: center;
 
-  .request-content {
-    flex: 1;
+  .request-container {
     display: flex;
-    flex-direction: row;
-    align-items: center;
+    flex-direction: column;
+    flex: 1;
 
-    .img {
-      object-fit: cover;
-      width: 150px;
-      height: 150px;
+    .request-action {
+      flex: 1;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
     }
   }
 }
@@ -21,7 +22,6 @@
   font-size: 16px;
   background-color: $snow;
   text-align: center;
-  width: 100%;
 }
 
 @media only screen and (max-width: 768px) {
@@ -40,13 +40,23 @@
 
 .request {
   display: flex;
-  flex-direction: column;
-  border-top: 8px solid $ochre;
+  flex-direction: row;
+
+  .img {
+    object-fit: cover;
+    width: 200px;
+    height: 200px;
+  }
 
   .request-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+
+  .attr-container {
+    border: 1px solid $snow;
+    background-color: rgba($snow, 0.4);
   }
 
   .attr {
@@ -72,6 +82,12 @@
       }
     }
   }
+}
+
+.request-buttons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .toggle {

--- a/app/assets/stylesheets/pages/Request.scss
+++ b/app/assets/stylesheets/pages/Request.scss
@@ -63,23 +63,22 @@
     display: flex;
     flex-direction: row;
     width: 100%;
+    @extend .mb2;
+
+    &:last-child {
+      margin: 0;
+    }
 
     .key {
-      width: 200px;
+      display: flex;
+      flex-direction: column;
+      flex: 1;
     }
 
     .value {
       display: flex;
       flex-direction: column;
-      flex-grow: 1;
-    }
-
-    .attr-item {
-      @extend .mb2;
-
-      &:last-child {
-        margin: 0;
-      }
+      flex: 4;
     }
   }
 }

--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -42,4 +42,11 @@ class Api::ArtistsController < ApplicationController
         each_serializer: RequestSerializer
   end
 
+  def commissions
+    artist = Artist.find(params[:id])
+    commissions = artist.commissions
+    render json: commissions,
+        each_serializer: CommissionSerializer
+  end
+
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -17,4 +17,7 @@ class ArtistsController < ApplicationController
 
   def transactions
   end
+
+  def commissions
+  end
 end

--- a/app/controllers/receipts_controller.rb
+++ b/app/controllers/receipts_controller.rb
@@ -10,7 +10,7 @@ class ReceiptsController < ApplicationController
 
   def get_receipt_type_enums
     # return type enums for dropdown
-    types = Receipt.types
+    types = Receipt.transaction_types
     render json: types
   end
 end

--- a/app/javascript/components/artists/ArtistSnapshot.jsx
+++ b/app/javascript/components/artists/ArtistSnapshot.jsx
@@ -2,27 +2,27 @@ import PropTypes from "prop-types";
 import React from "react";
 import UserSnapshot from "../helpers/UserSnapshot";
 
-class BuyerSnapshot extends React.Component {
+class ArtistSnapshot extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
   }
   
-  navigateToBuyer = () => {
-    window.location = `/buyers/${this.props.buyer.id}`;
+  navigateToArtist = () => {
+    window.location = `/artists/${this.props.artist.id}`;
   }
   
   render() {
     return (
       <UserSnapshot
-        name={this.props.buyer.name}
+        name={this.props.artist.name}
         avatarSrc=""
-        navigate={this.navigateToBuyer}
-        description={this.props.buyer.email}
+        navigate={this.navigateToArtist}
+        description={""}
       >
       </UserSnapshot>
     );
   }
 }
 
-export default BuyerSnapshot;
+export default ArtistSnapshot;

--- a/app/javascript/components/buyers/BuyerSnapshot.jsx
+++ b/app/javascript/components/buyers/BuyerSnapshot.jsx
@@ -1,0 +1,17 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+class BuyerSnapshot extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div />
+    )
+  }
+}
+
+export default BuyerSnapshot;

--- a/app/javascript/components/buyers/BuyerSnapshot.jsx
+++ b/app/javascript/components/buyers/BuyerSnapshot.jsx
@@ -1,15 +1,30 @@
 import PropTypes from "prop-types";
 import React from "react";
+import Touchable from 'rc-touchable';
 
 class BuyerSnapshot extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
   }
+  
+  navigateToBuyer = () => {
+    window.location = `/buyers/${this.props.buyer.id}`;
+  }
 
   render() {
     return (
-      <div />
+      <Touchable onPress={() => this.navigateToBuyer()}>
+        <div className="w5 bg-white snapshot pa3 pointer">
+          <div className="h2 w2 br-100 mr3 bg-gray self-center">
+            <img src="" />
+          </div>
+          <div className="snapshot-content">
+            <h5>{this.props.buyer.name}</h5>
+            <h6>{this.props.buyer.email}</h6>
+          </div>
+        </div>
+      </Touchable>
     )
   }
 }

--- a/app/javascript/components/commissions/Commission.jsx
+++ b/app/javascript/components/commissions/Commission.jsx
@@ -1,16 +1,75 @@
 import PropTypes from "prop-types";
 import React from "react";
+import BuyerSnapshot from "../buyers/BuyerSnapshot";
 
 class Commission extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      commissions: [],
+      componentDidMount: false
+    };
+  }
+  
+  componentDidMount() {
+    const route = APIRoutes.artists.commissions(this.props.artist.id);
+    Requester.get(route).then(
+      response => {
+        this.setState({ commissions: response, componentDidMount: true });
+      },
+      error => {
+        console.error(error);
+      }
+    );
+  }
+  
+  getAttr(commission) {
+    let attr = {
+      "Inquired On": new Date(commission.created_at).toLocaleDateString(),
+      "Inquiry Type": commission.types,
+      "Message": commission.comment,
+    };
+    
+    return Object.keys(attr).map((key, i) => {
+      return (
+        <div className="attr" key={i}>
+          <div className="key mr3">
+            <h5>{key}</h5>
+          </div>
+          <div className="value">
+            <h6 key={i}>{attr[key]}</h6>
+          </div>
+        </div>
+      );
+    });
   }
 
   render() {
+    if (!this.state.componentDidMount) {
+      return (
+        <div><h2>Loading</h2></div>
+      );
+    }
     return (
       <div className="mw7 center">
         <h1>Inquiries</h1>
+        {
+          this.state.commissions.map((commission) => {
+            console.log(commission);
+            return (
+              <div key={commission.id} className="request pa3 bg-white mb3">
+                <div className="request-container w-100">
+                  <div className="request-action">
+                    <BuyerSnapshot buyer={commission.buyer} />
+                  </div>
+                  <div className="attr-container w-100 pa3 mt2">
+                    {this.getAttr(commission)}
+                  </div>
+                </div>
+              </div>
+            )
+          })
+        }
       </div>
     )
   }

--- a/app/javascript/components/commissions/Commission.jsx
+++ b/app/javascript/components/commissions/Commission.jsx
@@ -55,7 +55,6 @@ class Commission extends React.Component {
         <h1>Inquiries</h1>
         {
           this.state.commissions.map((commission) => {
-            console.log(commission);
             return (
               <div key={commission.id} className="request pa3 bg-white mb3">
                 <div className="request-container w-100">

--- a/app/javascript/components/commissions/Commission.jsx
+++ b/app/javascript/components/commissions/Commission.jsx
@@ -1,0 +1,19 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+class Commission extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div className="mw7 center">
+        <h1>Inquiries</h1>
+      </div>
+    )
+  }
+}
+
+export default Commission;

--- a/app/javascript/components/helpers/None.jsx
+++ b/app/javascript/components/helpers/None.jsx
@@ -1,0 +1,30 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
+
+/**
+ * @prop itemType: Displays "No {itemType} to show."
+ */
+class None extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    if (this.props.itemType) {
+      return (
+        <div className="w-100 bg-snow pa2 pt3 pb3 error-container">
+          <FontAwesomeIcon className="gray" icon={faExclamationCircle}/>
+          <p className="error ml2 gray">No {this.props.itemType} to show.</p>
+        </div>
+      );
+    }
+    return (
+      <div />
+    );
+  }
+}
+
+export default None;

--- a/app/javascript/components/helpers/StyledModal.jsx
+++ b/app/javascript/components/helpers/StyledModal.jsx
@@ -34,8 +34,7 @@ class StyledModal extends React.Component {
             Cancel
           </button>
         </ReactModal>
-        <br />
-        <button className="button-primary bg-mustard w-100" onClick={this.showModal}>
+        <button className={"bg-" + this.props.color + " button-primary w-100"} onClick={this.showModal}>
           {this.props.title}
         </button>
       </div>

--- a/app/javascript/components/helpers/UserSnapshot.jsx
+++ b/app/javascript/components/helpers/UserSnapshot.jsx
@@ -1,0 +1,30 @@
+import PropTypes from "prop-types";
+import React from "react";
+import Touchable from 'rc-touchable';
+
+class UserSnapshot extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div className="w5 bg-white snapshot pa3">
+        <Touchable onPress={() => this.props.navigate()}>
+          <div className="h2 w2 br-100 mr3 bg-gray self-center snapshot-nav">
+            <img src={this.props.avatarSrc} />
+          </div>
+        </Touchable>
+        <div className="snapshot-content">
+          <Touchable onPress={() => this.props.navigate()}>
+            <h5 className="snapshot-nav">{this.props.name}</h5>
+          </Touchable>
+          <h6>{this.props.description}</h6>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default UserSnapshot;

--- a/app/javascript/components/requests/Receipt.jsx
+++ b/app/javascript/components/requests/Receipt.jsx
@@ -1,8 +1,9 @@
 import PropTypes from "prop-types";
 import React from "react";
 import BuyerSnapshot from "../buyers/BuyerSnapshot";
+import { convertToCurrency } from "../../utils/currency";
 
-class Request extends React.Component {
+class Receipt extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -13,37 +14,28 @@ class Request extends React.Component {
 
   getAttr = (request) => {
     let attr = {
+      "Price": "$" + convertToCurrency(request.receipt.price),
+      "Purchase Date": new Date(request.receipt.purchase_date).toLocaleDateString(),
+      "Transaction Type": request.receipt.transaction_type
     };
-
-    if (request.open) {
-      attr["Message"] = request.message;
-    } else if (request.receipt) {
-      if (request.receipt.transaction_type === "rental") {
-        attr["Start Date"] = request.receipt.start_date;
-        attr["End Date"] = request.receipt.end_date;
-      }
-      attr["Price"] = request.receipt.price;
-      attr["Purchase Date"] = request.receipt.purchase_date;
+    
+    if (request.receipt.transaction_type === "rental") {
+      attr["Start Date"] = new Date(request.receipt.start_date).toLocaleDateString();
+      attr["End Date"] = new Date(request.receipt.end_date).toLocaleDateString();
     }
 
-    return (
-      <div className="attr">
-        <div className="key">
-          {
-            Object.keys(attr).map((obj, i) => {
-              return <h5 key={i} className="attr-item">{obj}</h5>
-            })
-          }
+    return Object.keys(attr).map((key, i) => {
+      return (
+        <div className="attr" key={i}>
+          <div className="key mr3">
+            <h5>{key}</h5>
+          </div>
+          <div className="value">
+            <h6 key={i}>{attr[key]}</h6>
+          </div>
         </div>
-        <div className="value">
-          {
-            Object.keys(attr).map((obj, i) => {
-              return <h6 key={i} className="attr-item">{attr[obj]}</h6>
-            })
-          }
-        </div>
-      </div>
-    );
+      );
+    });
   }
 
   render() {
@@ -63,11 +55,11 @@ class Request extends React.Component {
                 {
                   this.props.artist ? (
                     <div className = "closed-request-button pa3 w5">
-                      <p> You reviewed this request on {closed_timestamps} </p>
+                      <p> You completed this request on {closed_timestamps} </p>
                     </div>
                   ) : (
                     <div className = "closed-request-button pa3 w5">
-                      <p>{request.artist.name} reviewed this request on {closed_timestamps} </p>
+                      <p>{request.artist.name} completed this request on {closed_timestamps} </p>
                     </div>
                   )
                 }
@@ -83,4 +75,4 @@ class Request extends React.Component {
   }
 }
 
-export default Request;
+export default Receipt;

--- a/app/javascript/components/requests/Receipt.jsx
+++ b/app/javascript/components/requests/Receipt.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import BuyerSnapshot from "../buyers/BuyerSnapshot";
+import ArtistSnapshot from "../artists/ArtistSnapshot";
 import { convertToCurrency } from "../../utils/currency";
 
 class Receipt extends React.Component {
@@ -51,20 +52,23 @@ class Receipt extends React.Component {
         <div className="w-100 ml4">
           <div className="content-row">
             <div className="request-container">
-              <div className="request-action">
-                <BuyerSnapshot buyer={this.state.request.buyer} />
-                {
-                  this.props.artist ? (
+              {
+                this.props.artist ? (
+                  <div className="request-action">
+                    <BuyerSnapshot buyer={this.state.request.buyer} />
                     <div className = "closed-request-button pa3 w5">
                       <p> You completed this request on {closed_timestamps} </p>
                     </div>
-                  ) : (
+                  </div>
+                ) : (
+                  <div className="request-action">
+                    <ArtistSnapshot artist={this.state.request.artist} />
                     <div className = "closed-request-button pa3 w5">
                       <p>{request.artist.name} completed this request on {closed_timestamps} </p>
                     </div>
-                  )
-                }
-              </div>
+                  </div>
+                )
+              }
               <div className="attr-container pa3 mt2">
                 {this.getAttr(request)}
               </div>

--- a/app/javascript/components/requests/Receipt.jsx
+++ b/app/javascript/components/requests/Receipt.jsx
@@ -1,7 +1,5 @@
 import PropTypes from "prop-types";
 import React from "react";
-import StyledModal from "../helpers/StyledModal";
-import CreateTransaction from "../transactions/CreateTransaction";
 import BuyerSnapshot from "../buyers/BuyerSnapshot";
 
 class Request extends React.Component {
@@ -13,28 +11,8 @@ class Request extends React.Component {
     };
   }
 
-  closeRequest = (id) => {
-    const update_request_route = APIRoutes.requests.update(id);
-    Requester.update(update_request_route, {open: false}).then((response) => {
-      this.props.onChange();
-    });
-  }
-
-  getRequestStatus = (request) => {
-    if (request.open) {
-      return "Pending";
-    } else {
-      if (request.receipt) {
-        return "Complete";
-      }
-      return "Closed";
-    }
-  }
-
   getAttr = (request) => {
     let attr = {
-      "Placed": new Date(request.updated_at).toLocaleDateString(),
-      "Request Type": request.types
     };
 
     if (request.open) {
@@ -67,38 +45,6 @@ class Request extends React.Component {
       </div>
     );
   }
-  
-  renderRequestButtons() {
-    const closed_timestamps = new Date(this.state.request.updated_at).toLocaleDateString();
-    if (!this.state.request.open) {
-      return (
-        <div className="closed-request-button pa3 w5">
-          <p> You archived this request on {closed_timestamps} </p>
-        </div>
-      );
-    }
-    let id = this.state.request.id;
-    return (
-      <div className="request-buttons">
-        <div className="w4">
-          <button type="button" className="button-secondary b--charcoal w-100" value = {id} onClick = {()=>this.closeRequest(id)}>
-            ARCHIVE
-          </button>
-        </div>
-        <div className="ml3 w4">
-          <StyledModal
-            title="COMPLETE"
-            color="ochre"
-          >
-            <CreateTransaction
-              artist={this.props.artist}
-              request_id={id}
-            />
-          </StyledModal>
-        </div>
-      </div>
-    )
-  }
 
   render() {
     const request = this.state.request;
@@ -115,11 +61,13 @@ class Request extends React.Component {
               <div className="request-action">
                 <BuyerSnapshot buyer={this.state.request.buyer} />
                 {
-                  this.props.artist ? 
-                    this.renderRequestButtons()
-                   : (
-                    <div className = "closed-request-button pa4 w5">
-                      <p> You requested this work on {closed_timestamps} </p>
+                  this.props.artist ? (
+                    <div className = "closed-request-button pa3 w5">
+                      <p> You reviewed this request on {closed_timestamps} </p>
+                    </div>
+                  ) : (
+                    <div className = "closed-request-button pa3 w5">
+                      <p>{request.artist.name} reviewed this request on {closed_timestamps} </p>
                     </div>
                   )
                 }

--- a/app/javascript/components/requests/Receipt.jsx
+++ b/app/javascript/components/requests/Receipt.jsx
@@ -16,7 +16,8 @@ class Receipt extends React.Component {
     let attr = {
       "Price": "$" + convertToCurrency(request.receipt.price),
       "Purchase Date": new Date(request.receipt.purchase_date).toLocaleDateString(),
-      "Transaction Type": request.receipt.transaction_type
+      "Transaction Type": request.receipt.transaction_type,
+      "Description": request.receipt.comment
     };
     
     if (request.receipt.transaction_type === "rental") {

--- a/app/javascript/components/requests/Request.jsx
+++ b/app/javascript/components/requests/Request.jsx
@@ -15,7 +15,7 @@ class Request extends React.Component {
 
   closeRequest = (id) => {
     const update_request_route = APIRoutes.requests.update(id);
-    Requester.update(update_request_route, {open: false}).then((response) => {
+    Requester.update(update_request_route, { open: false }).then((response) => {
       this.props.onChange();
     });
   }
@@ -51,7 +51,7 @@ class Request extends React.Component {
       );
     });
   }
-  
+
   renderRequestButtons() {
     const closed_timestamps = new Date(this.state.request.updated_at).toLocaleDateString();
     if (!this.state.request.open) {
@@ -65,7 +65,7 @@ class Request extends React.Component {
     return (
       <div className="request-buttons">
         <div className="w4">
-          <button type="button" className="button-secondary b--charcoal w-100" value = {id} onClick = {()=>this.closeRequest(id)}>
+          <button type="button" className="button-secondary b--charcoal w-100" value={id} onClick={() => this.closeRequest(id)}>
             ARCHIVE
           </button>
         </div>
@@ -92,25 +92,23 @@ class Request extends React.Component {
 
     return (
       <div key={request.id} className="request pa3 bg-white mb3">
-        <img src={thumbnail_url} className="img"/>
+        <img src={thumbnail_url} className="img" />
         <div className="w-100 ml4">
-          <div className="content-row">
-            <div className="request-container">
-              <div className="request-action">
-                <BuyerSnapshot buyer={this.state.request.buyer} />
-                {
-                  this.props.artist ? 
-                    this.renderRequestButtons()
-                   : (
-                    <div className = "closed-request-button pa4 w5">
+          <div className="request-container">
+            <div className="request-action">
+              <BuyerSnapshot buyer={this.state.request.buyer} />
+              {
+                this.props.artist ?
+                  this.renderRequestButtons()
+                  : (
+                    <div className="closed-request-button pa4 w5">
                       <p> You requested this work on {closed_timestamps} </p>
                     </div>
                   )
-                }
-              </div>
-              <div className="attr-container pa3 mt2">
-                {this.getAttr(request)}
-              </div>
+              }
+            </div>
+            <div className="attr-container pa3 mt2">
+              {this.getAttr(request)}
             </div>
           </div>
         </div>

--- a/app/javascript/components/requests/Request.jsx
+++ b/app/javascript/components/requests/Request.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import StyledModal from "../helpers/StyledModal";
 import CreateTransaction from "../transactions/CreateTransaction";
 import BuyerSnapshot from "../buyers/BuyerSnapshot";
+import ArtistSnapshot from "../artists/ArtistSnapshot";
 
 class Request extends React.Component {
   constructor(props) {
@@ -95,18 +96,21 @@ class Request extends React.Component {
         <img src={thumbnail_url} className="img" />
         <div className="w-100 ml4">
           <div className="request-container">
-            <div className="request-action">
-              <BuyerSnapshot buyer={this.state.request.buyer} />
-              {
-                this.props.artist ?
-                  this.renderRequestButtons()
-                  : (
-                    <div className="closed-request-button pa4 w5">
-                      <p> You requested this work on {closed_timestamps} </p>
-                    </div>
-                  )
-              }
-            </div>
+            {
+              this.props.artist ? (
+                <div className="request-action">
+                  <BuyerSnapshot buyer={this.state.request.buyer} />
+                  {this.renderRequestButtons()}
+                </div>
+              ) : (
+                <div className="request-action">
+                  <ArtistSnapshot artist={this.state.request.artist} />
+                  <div className="closed-request-button pa4 w5">
+                    <p> You requested this work on {closed_timestamps} </p>
+                  </div>
+                </div>
+              )
+            }
             <div className="attr-container pa3 mt2">
               {this.getAttr(request)}
             </div>

--- a/app/javascript/components/requests/Request.jsx
+++ b/app/javascript/components/requests/Request.jsx
@@ -34,38 +34,22 @@ class Request extends React.Component {
   getAttr = (request) => {
     let attr = {
       "Placed": new Date(request.updated_at).toLocaleDateString(),
-      "Request Type": request.types
+      "Request Type": request.types,
+      "Message": request.message
     };
 
-    if (request.open) {
-      attr["Message"] = request.message;
-    } else if (request.receipt) {
-      if (request.receipt.transaction_type === "rental") {
-        attr["Start Date"] = request.receipt.start_date;
-        attr["End Date"] = request.receipt.end_date;
-      }
-      attr["Price"] = request.receipt.price;
-      attr["Purchase Date"] = request.receipt.purchase_date;
-    }
-
-    return (
-      <div className="attr">
-        <div className="key">
-          {
-            Object.keys(attr).map((obj, i) => {
-              return <h5 key={i} className="attr-item">{obj}</h5>
-            })
-          }
+    return Object.keys(attr).map((key, i) => {
+      return (
+        <div className="attr" key={i}>
+          <div className="key mr3">
+            <h5>{key}</h5>
+          </div>
+          <div className="value">
+            <h6 key={i}>{attr[key]}</h6>
+          </div>
         </div>
-        <div className="value">
-          {
-            Object.keys(attr).map((obj, i) => {
-              return <h6 key={i} className="attr-item">{attr[obj]}</h6>
-            })
-          }
-        </div>
-      </div>
-    );
+      );
+    });
   }
   
   renderRequestButtons() {

--- a/app/javascript/components/requests/UserRequests.jsx
+++ b/app/javascript/components/requests/UserRequests.jsx
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 import Request from "./Request";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAngleDoubleRight } from "@fortawesome/free-solid-svg-icons";
 
 class UserRequests extends React.Component {
   constructor(props) {
@@ -16,9 +18,11 @@ class UserRequests extends React.Component {
 
   renderToggle() {
     return this.toggleState.map((state, i) => {
+      let active = i === this.state.state;
       return (
-        <div key={i} onClick={() => this.display(i)} className={(state === "Requests" ? "bg-charcoal" : "bg-mustard") + " pa2 mt2 toggle"}>
-          <h4 className="white">{state}</h4>
+        <div key={i} onClick={() => this.display(i)} className={(active ? "bg-ochre" : "toggle-hover") + " pa3 mt2 toggle"}>
+          <h3 className={active ? "white" : "charcoal"}>{state}</h3>
+          <FontAwesomeIcon className={(active ? "white" : "charcoal") + " ml2"} icon={faAngleDoubleRight}/>
         </div>
       );
     });

--- a/app/javascript/components/requests/UserRequests.jsx
+++ b/app/javascript/components/requests/UserRequests.jsx
@@ -28,6 +28,10 @@ class UserRequests extends React.Component {
       );
     });
   }
+  
+  isReceipt(request) {
+    return !request.open && request.receipt;
+  }
 
   display = (i) => {
     let display = []
@@ -46,7 +50,7 @@ class UserRequests extends React.Component {
         break;
       case "Complete":
         this.state.inbox.slice().map((request, i) => {
-          if (!request.open && request.receipt) {
+          if (this.isReceipt(request)) {
             display.push(i);
           }
         });
@@ -97,15 +101,28 @@ class UserRequests extends React.Component {
         </div>
       )
     }
-    return this.state.display.map((i) => (
-      <Request
-        request={this.state.inbox[i]}
-        artist={this.props.artist}
-        buyer={this.props.buyer}
-        onChange={() => this.fetchInboxData()}
-        key={i}
-      />
-    ));
+    return this.state.display.map((i) => {
+      if (this.isReceipt(this.state.inbox[i])) {
+        return (
+          <Receipt
+            request={this.state.inbox[i]}
+            artist={this.props.artist}
+            buyer={this.props.buyer}
+            onChange={() => this.fetchInboxData()}
+            key={i}
+          />
+        )
+      }
+      return (
+        <Request
+          request={this.state.inbox[i]}
+          artist={this.props.artist}
+          buyer={this.props.buyer}
+          onChange={() => this.fetchInboxData()}
+          key={i}
+        />
+      );
+    });
   }
 
   render() {

--- a/app/javascript/components/requests/UserRequests.jsx
+++ b/app/javascript/components/requests/UserRequests.jsx
@@ -3,8 +3,7 @@ import React from "react";
 import Request from "./Request";
 import Receipt from "./Receipt";
 import None from "../helpers/None";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faAngleDoubleRight } from "@fortawesome/free-solid-svg-icons";
+import classNames from "classnames";
 
 class UserRequests extends React.Component {
   constructor(props) {
@@ -22,21 +21,20 @@ class UserRequests extends React.Component {
     return this.toggleState.map((state, i) => {
       let active = i === this.state.state;
       return (
-        <div key={i} onClick={() => this.display(i)} className={(active ? "bg-ochre" : "toggle-hover") + " pa3 mt2 toggle"}>
-          <h3 className={active ? "white" : "charcoal"}>{state}</h3>
-          <FontAwesomeIcon className={(active ? "white" : "charcoal") + " ml2"} icon={faAngleDoubleRight}/>
+        <div key={i} onClick={() => this.display(i)} className={classNames("mb2 toggle", (active ? "bg-ochre" : "toggle-hover"))}>
+          <p className={classNames("strong", { "white": active })}>{state} »</p>
         </div>
       );
     });
   }
-  
+
   isReceipt(request) {
     return !request.open && request.receipt;
   }
 
   display = (i) => {
     let display = []
-    switch(this.toggleState[parseInt(i)]) {
+    switch (this.toggleState[parseInt(i)]) {
       case "Requests":
         this.state.inbox.map((request, i) => {
           display.push(i);
@@ -93,12 +91,12 @@ class UserRequests extends React.Component {
       );
     });
   }
-  
+
   renderRequests() {
     if (!this.state.display.length) {
       return (
         <div className="bg-white pa2">
-          <None itemType="requests"/>
+          <None itemType="requests" />
         </div>
       )
     }
@@ -134,7 +132,7 @@ class UserRequests extends React.Component {
     }
     return (
       <div className="mw8 center">
-        <div className="w-20 fl pr3 mt5">
+        <div className="w-20 fl pr4 mt6">
           {this.renderToggle()}
         </div>
         <div className="w-80 fl mt2">

--- a/app/javascript/components/requests/UserRequests.jsx
+++ b/app/javascript/components/requests/UserRequests.jsx
@@ -133,7 +133,7 @@ class UserRequests extends React.Component {
       );
     }
     return (
-      <div className="mw9 center">
+      <div className="mw8 center">
         <div className="w-20 fl pr3 mt5">
           {this.renderToggle()}
         </div>

--- a/app/javascript/components/requests/UserRequests.jsx
+++ b/app/javascript/components/requests/UserRequests.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import Request from "./Request";
+import Receipt from "./Receipt";
 import None from "../helpers/None";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDoubleRight } from "@fortawesome/free-solid-svg-icons";

--- a/app/javascript/components/requests/UserRequests.jsx
+++ b/app/javascript/components/requests/UserRequests.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import Request from "./Request";
+import None from "../helpers/None";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDoubleRight } from "@fortawesome/free-solid-svg-icons";
 
@@ -87,6 +88,25 @@ class UserRequests extends React.Component {
       );
     });
   }
+  
+  renderRequests() {
+    if (!this.state.display.length) {
+      return (
+        <div className="bg-white pa2">
+          <None itemType="requests"/>
+        </div>
+      )
+    }
+    return this.state.display.map((i) => (
+      <Request
+        request={this.state.inbox[i]}
+        artist={this.props.artist}
+        buyer={this.props.buyer}
+        onChange={() => this.fetchInboxData()}
+        key={i}
+      />
+    ));
+  }
 
   render() {
     if (!this.state.componentDidMount) {
@@ -96,20 +116,12 @@ class UserRequests extends React.Component {
     }
     return (
       <div className="mw9 center">
-        <div className="w-20 fl pr3 mt6">
+        <div className="w-20 fl pr3 mt5">
           {this.renderToggle()}
         </div>
         <div className="w-80 fl mt2">
           <h1>Requests</h1>
-          {this.state.display.map((i) => (
-            <Request
-              request={this.state.inbox[i]}
-              artist={this.props.artist}
-              buyer={this.props.buyer}
-              onChange={() => this.fetchInboxData()}
-              key={i}
-            />
-          ))}
+          {this.renderRequests()}
         </div>
       </div>
     );

--- a/app/javascript/components/transactions/CreateTransaction.jsx
+++ b/app/javascript/components/transactions/CreateTransaction.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
+import { convertToCurrency } from "../../utils/currency";
 
 /**
 * @prop artist: artist creating transaction
@@ -216,21 +217,6 @@ class CreateTransaction extends React.Component {
     }
   }
 
-  currencyDisplay = (inputPrice) => {
-    let value = new String(inputPrice);
-    // remove all characters that aren't a digit or dot
-    value = value.replace(/[^0-9.]/g,'');
-    // replace multiple dots with a single dot
-    value = value.replace(/\.+/g,'.');
-    // only allow 2 digits after a dot
-    value = value.replace(/(.*\.[0-9][0-9]?).*/g,'$1');
-    // replace multiple zeros with a single one
-    value = value.replace(/^0+(.*)$/,'0$1');
-    // remove leading zero
-    value = value.replace(/^0([^.].*)$/,'$1');
-    return value;
-  }
-
 render() {
 
   if (!this.state.didMount) {
@@ -246,7 +232,7 @@ render() {
           type="TEXT"
           name="price"
           id="price"
-          value={this.currencyDisplay(this.state.transaction.price)}
+          value={convertToCurrency(this.state.transaction.price)}
           onChange = {this.handleChange}
         />
 

--- a/app/javascript/utils/currency.js
+++ b/app/javascript/utils/currency.js
@@ -1,0 +1,14 @@
+export const convertToCurrency = (inputPrice) => {
+  let value = new String(inputPrice);
+  // remove all characters that aren't a digit or dot
+  value = value.replace(/[^0-9.]/g,'');
+  // replace multiple dots with a single dot
+  value = value.replace(/\.+/g,'.');
+  // only allow 2 digits after a dot
+  value = value.replace(/(.*\.[0-9][0-9]?).*/g,'$1');
+  // replace multiple zeros with a single one
+  value = value.replace(/^0+(.*)$/,'0$1');
+  // remove leading zero
+  value = value.replace(/^0([^.].*)$/,'$1');
+  return value;
+}

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -7,5 +7,6 @@ class Artist < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :works
   has_many :requests
+  has_many :commissions
   has_many :buyers, through: :commissions
 end

--- a/app/models/buyer.rb
+++ b/app/models/buyer.rb
@@ -5,5 +5,6 @@ class Buyer < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :requests
   has_many :works, through: :requests
+  has_many :commissions
   has_many :artists, through: :commissions
 end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -1,4 +1,4 @@
 class Receipt < ApplicationRecord
   belongs_to :request
-  enum types: { purchase: 0, rental: 1 }
+  enum transaction_type: { purchase: 0, rental: 1 }
 end

--- a/app/serializers/commission_serializer.rb
+++ b/app/serializers/commission_serializer.rb
@@ -1,0 +1,14 @@
+class CommissionSerializer < ActiveModel::Serializer
+  attributes :id, :comment, :types, :artist, :buyer, :created_at
+
+  belongs_to :buyer
+  belongs_to :artist
+
+  def artist
+    object.artist
+  end
+
+  def buyer
+    object.buyer
+  end
+end

--- a/app/serializers/request_serializer.rb
+++ b/app/serializers/request_serializer.rb
@@ -6,7 +6,7 @@ class RequestSerializer < ActiveModel::Serializer
   belongs_to :artist
   has_one :receipt
 
-  def work
+  def artist
     object.artist
   end
 

--- a/app/views/artists/commissions.html.slim
+++ b/app/views/artists/commissions.html.slim
@@ -1,0 +1,2 @@
+.container.dashboard-container
+  = react_component "commissions/Commission", {artist: @artist}

--- a/app/views/artists/commissions.html.slim
+++ b/app/views/artists/commissions.html.slim
@@ -1,2 +1,2 @@
 .container.dashboard-container
-  = react_component "commissions/Commission", {artist: @artist}
+  = react_component "commissions/Commission", {artist: current_artist}

--- a/app/views/partials/_header.html.slim
+++ b/app/views/partials/_header.html.slim
@@ -42,6 +42,8 @@ nav.header
                     li.dropdown-link-item
                       = link_to "Requests", requests_path
                     li.dropdown-link-item
+                      = link_to "Inquiries", commissions_path
+                    li.dropdown-link-item
                       = link_to "Log Out", destroy_artist_session_path, method: :delete
           - if current_buyer
               div.dropdown

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   get '/buyers/:id' => 'buyers#show', as: :buyerid
 
   get '/commissions/types' => 'commissions#get_type_enum'
+  get '/commissions' => 'artists#commissions', as: :commissions
 
 
   namespace :api, defaults: { format: :json } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,5 +50,6 @@ Rails.application.routes.draw do
     get 'works/filtered_works/:search_params' => 'works#filtered_works'
     get 'receipts/artist/:id' => 'artists#receipts'
     get 'works/thumbnail/:id' => 'works#thumbnail'
+    get 'artists/commissions/:id' => 'artists#commissions'
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -84,7 +84,7 @@ Lisa.save!
 
 #Lisa's id is 1
 lisa_request = Request.create(
-  message: 'I would like to request the Mona Lisa',
+  message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ipsum dolor sit amet consectetur adipiscing elit duis tristique.',
   types: 0
   )
 lisa_request.buyer = Gates


### PR DESCRIPTION
## Display Commissions, Re-Style Requests
- Request styling needed to be reconsidered: once completed, the request is irrelevant
- Creates separate components for requests and receipts (completed requests)
- Renders inquiries for artists (contact form on artist profile page)
- Adds `BuyerSnapshot` component, which is a small panel that links to the buyer profile page and contains basic information such as name and email
- Restyles toggle functionality to be more interactive, active state is colored
- Also addresses some strange bugfixes with serializers and enums
- Once works tiling is merged in, the image of the work will be replaced with a hoverable tile that navigates to the work

### Related PRs

Alison's transactions PR, but merge conflicts shouldn't be too difficult to resolve

### Screenshots
![image](https://user-images.githubusercontent.com/29110579/49008238-32e74700-f122-11e8-8574-77ee1827bb8a.png)
![image](https://user-images.githubusercontent.com/29110579/49008476-ca4c9a00-f122-11e8-816b-acdc3600d526.png)


CC: @clairelin135
