### PR TITLE
Claire/style receipts

### DIFF
--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -99,6 +99,7 @@ input[type="checkbox"] {
   @extend .row-input;
   outline: none;
   height: 45px;
+  box-sizing: border-box;
 }
 
 .input-dropdown {
@@ -128,4 +129,11 @@ input[type="checkbox"] {
   &:hover {
     background-color: rgba($charcoal, 0.8);
   }
+}
+
+.price {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
 }

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -119,6 +119,7 @@ input[type="checkbox"] {
 }
 
 .hover-button {
+  outline: none;
   border: none;
   display: flex;
   flex-direction: row;

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -118,6 +118,7 @@ input[type="checkbox"] {
 }
 
 .hover-button {
+  border: none;
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/app/assets/stylesheets/components/_overlay.scss
+++ b/app/assets/stylesheets/components/_overlay.scss
@@ -1,0 +1,5 @@
+.overlay {
+  position: absolute;
+  z-index: 1;
+  
+}

--- a/app/assets/stylesheets/components/modal.scss
+++ b/app/assets/stylesheets/components/modal.scss
@@ -11,6 +11,32 @@
   background-color: white;
   border-top: 8px solid $mustard;
   outline: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  $modal-head-height: 40px;
+
+  .modal-head {
+    position: absolute;
+    height: $modal-head-height;
+    width: 100%;
+    z-index: 2;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: 0px 5px 5px rgba(black, 0.1);
+  }
+
+  .modal-content {
+    position: absolute;
+    top: $modal-head-height;
+    width: 100%;
+    bottom: 0;
+    overflow: scroll;
+  }
+}
 
 .cancel-button {
   background-color: white;
@@ -20,7 +46,6 @@
   text-decoration: none;
   display: inline-block;
   font-size: 18px;
-  }
 }
 
 .overlay-class {

--- a/app/assets/stylesheets/components/modal.scss
+++ b/app/assets/stylesheets/components/modal.scss
@@ -2,8 +2,8 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  height: 600px;
-  width: 800px;
+  height: 500px;
+  width: 600px;
   right: auto;
   bottom: auto;
   margin-right: -50%;

--- a/app/assets/stylesheets/pages/Request.scss
+++ b/app/assets/stylesheets/pages/Request.scss
@@ -55,6 +55,17 @@
   .attr-container {
     border: 1px solid $snow;
     background-color: rgba($snow, 0.4);
+
+    &:hover {
+      .overlay-button {
+        visibility: visible;
+      }
+    }
+
+    .overlay-button {
+      right: 16px;
+      visibility: hidden;
+    }
   }
 
   .attr {

--- a/app/assets/stylesheets/pages/Transactions.scss
+++ b/app/assets/stylesheets/pages/Transactions.scss
@@ -6,16 +6,3 @@
   font-size: 16px;
   line-height: 20px;
 }
-
-.create-transaction-form {
-  text-align: left;
-
-  .submit {
-    margin-top: -50px;
-    color: white;
-  }
-
-  .price {
-    margin-top: 20px;
-  }
-}

--- a/app/assets/stylesheets/partials/_fonts.scss
+++ b/app/assets/stylesheets/partials/_fonts.scss
@@ -2,6 +2,10 @@
 
 $font : 'Roboto', sans-serif;
 
+.font {
+	font-family: $font;
+}
+
 html, body {
 	font-family: $font;
 	color: $text;

--- a/app/javascript/components/artists/ArtistProfile.jsx
+++ b/app/javascript/components/artists/ArtistProfile.jsx
@@ -5,6 +5,7 @@ import WorkColumnPanel from "../works/WorkColumnPanel";
 import Touchable from 'rc-touchable';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEdit, faTrash } from "@fortawesome/free-solid-svg-icons";
+import Button from "../helpers/Button";
 
 /**
 * @prop user: user currently logged in
@@ -124,18 +125,14 @@ class ArtistProfile extends React.Component {
               <WorkColumnPanel work={work}>
                 {canEditProfile &&
                   <div className="work-action-wrapper mb2">
-                    <Touchable onPress={() => this.updateWork(work.id)}>
-                      <div className="hover-button pa2 pointer">
-                        <FontAwesomeIcon className="white" icon={faEdit}/>
-                        <h4 className="ml2 white">Edit</h4>
-                      </div>
-                    </Touchable>
-                    <Touchable onPress={() => this.deleteWork(work.id)}>
-                      <div className="hover-button pa2 ml2 pointer">
-                        <FontAwesomeIcon className="white" icon={faTrash}/>
-                        <h4 className="ml2 white">Delete</h4>
-                      </div>
-                    </Touchable>
+                    <Button type="hover-button" onClick={() => this.updateWork(work.id)}>
+                      <FontAwesomeIcon className="white" icon={faEdit}/>
+                      <h4 className="ml2 white">Edit</h4>
+                    </Button>
+                    <Button className="ml2" type="hover-button" onClick={() => this.deleteWork(work.id)}>
+                      <FontAwesomeIcon className="white" icon={faTrash}/>
+                      <h4 className="ml2 white">Delete</h4>
+                    </Button>
                   </div>
                 }
               </WorkColumnPanel>

--- a/app/javascript/components/helpers/Button.jsx
+++ b/app/javascript/components/helpers/Button.jsx
@@ -11,13 +11,13 @@ class Button extends React.Component {
     switch(this.props.type) {
       case "button-primary":
         return (
-          <button className={this.props.className + " button-primary bg-" + this.props.color} onClick={this.props.onClick}>
+          <button className={this.props.className + " button-primary font bg-" + this.props.color} onClick={this.props.onClick}>
             {this.props.children}
           </button>
         );
       case "button-secondary":
         return (
-          <button className={this.props.className + " button-secondary b--" + this.props.color} onClick={this.props.onClick}>
+          <button className={this.props.className + " button-secondary font b--" + this.props.color} onClick={this.props.onClick}>
             {this.props.children}
           </button>
         );
@@ -29,7 +29,7 @@ class Button extends React.Component {
         )
       case "hover-button":
         return (
-          <button className={this.props.className + " hover-button pa2"} onClick={this.props.onClick}>
+          <button className={this.props.className + " hover-button pa2 white font pointer"} onClick={this.props.onClick}>
             {this.props.children}
           </button>
         )

--- a/app/javascript/components/helpers/Button.jsx
+++ b/app/javascript/components/helpers/Button.jsx
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+class Button extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    switch(this.props.type) {
+      case "button-primary":
+        return (
+          <button className={this.props.className + " button-primary bg-" + this.props.color} onClick={this.props.onClick}>
+            {this.props.children}
+          </button>
+        );
+      case "button-secondary":
+        return (
+          <button className={this.props.className + " button-secondary b--" + this.props.color} onClick={this.props.onClick}>
+            {this.props.children}
+          </button>
+        );
+      case "button-tertiary":
+        return (
+          <button className={this.props.className + " button-tertiary " + this.props.color} onClick={this.props.onClick}>
+            {this.props.children}
+          </button>
+        )
+      case "hover-button":
+        return (
+          <button className={this.props.className + " hover-button pa2"} onClick={this.props.onClick}>
+            {this.props.children}
+          </button>
+        )
+    }
+  }
+}
+
+export default Button;

--- a/app/javascript/components/helpers/StyledModal.jsx
+++ b/app/javascript/components/helpers/StyledModal.jsx
@@ -1,6 +1,10 @@
 import PropTypes from "prop-types";
 import React from "react";
 import ReactModal from "react-modal";
+import Button from "../helpers/Button";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import Touchable from 'rc-touchable';
 
 class StyledModal extends React.Component {
   constructor(props) {
@@ -22,21 +26,28 @@ class StyledModal extends React.Component {
     return (
       <div>
         <ReactModal
-          className="pa3 modal"
+          className="modal"
           isOpen={this.state.show}
           onRequestClose={this.hideModal}
           ariaHideApp={false}
           overlayClassName="overlay-class"
-          >
-          <h2 className="f4 lh-title submit">{this.props.title}</h2>
-          {this.props.children}
+        >
+          <div className="modal-head bg-white pl3 pr3">
+            <h3>{this.props.title}</h3>
+            <Touchable onPress={this.hideModal}>
+              <FontAwesomeIcon className="gray pointer" icon={faTimes}/>
+            </Touchable>
+          </div>
+          <div className="modal-content pa4">
+            {this.props.children}
+          </div>
           <button className="cancel-button" onClick={this.hideModal}>
             Cancel
           </button>
         </ReactModal>
-        <button className={"bg-" + this.props.color + " button-primary w-100"} onClick={this.showModal}>
+        <Button className="w4" type={this.props.buttonType} color="ochre" onClick={this.showModal}>
           {this.props.title}
-        </button>
+        </Button>
       </div>
     );
   }

--- a/app/javascript/components/receipts/TransactionForm.jsx
+++ b/app/javascript/components/receipts/TransactionForm.jsx
@@ -170,14 +170,13 @@ class TransactionForm extends React.Component {
     }
   }
 
-render() {
-
-  if (!this.state.didMount) {
+  render() {
+    if (!this.state.didMount) {
+      return (
+        <div><h2>Loading</h2></div>
+      );
+    }
     return (
-      <div><h2>Loading</h2></div>
-    );
-  }
-  return (
       <div className="create-transaction-form">
 
         <p className="f6 lh-copy price">Price  </p>
@@ -198,8 +197,6 @@ render() {
               {  Object.keys(this.state.types).map((obj, i) => { return <option key={i}>{obj}</option> }) }
           </select>
         </p>
-
-        { console.log(this.state.receipt.transaction_type) }
 
         <FormError error={this.state.errors["transaction_type"]}/>
 

--- a/app/javascript/components/receipts/TransactionForm.jsx
+++ b/app/javascript/components/receipts/TransactionForm.jsx
@@ -2,6 +2,8 @@ import PropTypes from "prop-types";
 import React from "react";
 import FormError from '../helpers/FormError';
 import { convertToCurrency } from "../../utils/currency";
+import WorkFixedPanel from "../works/WorkFixedPanel";
+import Button from "../helpers/Button";
 
 /**
 * @prop artist: artist creating transaction
@@ -121,49 +123,27 @@ class TransactionForm extends React.Component {
     )
   }
 
-  renderPurchaseDate = () => {
-    if (this.state.receipt.transaction_type === "purchase") {
-      return (
-        <div>
-          <p className="f6 lh-copy">Purchase Date </p>
-          <input
-            type="date"
-            name="purchase_date"
-            id="purchase_date"
-            value={this.state.receipt.purchase_date}
-            onChange={this.handleChange}
-          />
-
-          <FormError error={this.state.errors["purchase_date"]}/>
-        </div>
-      )
-    }
-  }
-
   renderRentalDates = () => {
     if (this.state.receipt.transaction_type === "rental") {
       return (
         <div>
-          <p className="f6 lh-copy">Start Date  </p>
+          <h5>Start Date</h5>
           <input
             type="date"
             name="start_date"
-            id="start_date"
+            className="textinput"
             value={this.state.receipt.start_date}
             onChange={this.handleChange}
           />
-
           <FormError error={this.state.errors["start_date"]}/>
-
-          <p className="f6 lh-copy">End Date  </p>
+          <h5>End Date</h5>
           <input
             type="date"
             name="end_date"
-            id="end_date"
+            className="textinput"
             value={this.state.receipt.end_date}
             onChange={this.handleChange}
           />
-
           <FormError error={this.state.errors["end_date"]}/>
         </div>
       )
@@ -177,56 +157,57 @@ class TransactionForm extends React.Component {
       );
     }
     return (
-      <div className="create-transaction-form">
-
-        <p className="f6 lh-copy price">Price  </p>
-        $<input
-          type="TEXT"
-          name="price"
-          id="price"
-          value={convertToCurrency(this.state.receipt.price)}
-          onChange = {this.handleChange}
-        />
-
-        <FormError error={this.state.errors["price"]}/>
-
-        <p className="f6 lh-copy">Type
-          <select name="transaction_type"
-                  value={this.state.receipt.transaction_type}
-                  onChange={this.handleChange}>
-              {  Object.keys(this.state.types).map((obj, i) => { return <option key={i}>{obj}</option> }) }
+      <div className="w-100">
+        <div className="fl w-30">
+          <WorkFixedPanel work={this.props.work}/>
+        </div>
+        <div className="fl w-70 pl3">
+          <h5>Price</h5>
+          <div className="price">
+            <h5 className="mr2">$</h5>
+            <input
+              type="TEXT"
+              name="price"
+              value={convertToCurrency(this.state.receipt.price)}
+              onChange = {this.handleChange}
+              className="textinput"
+            />
+          </div>
+          <FormError error={this.state.errors["price"]}/>
+          <h5>Type</h5>
+          <select
+            name="transaction_type"
+            value={this.state.receipt.transaction_type}
+            onChange={this.handleChange}
+            className="input-dropdown"
+          >
+            {  Object.keys(this.state.types).map((obj, i) => { return <option key={i}>{obj}</option> }) }
           </select>
-        </p>
-
-        <FormError error={this.state.errors["transaction_type"]}/>
-
-        { this.renderRentalDates() }
-
-        <p className="f6 lh-copy">Purchase Date </p>
-        <input
-          type="date"
-          name="purchase_date"
-          id="purchase_date"
-          value={this.state.receipt.purchase_date}
-          onChange={this.handleChange}
-        />
-
-        <FormError error={this.state.errors["purchase_date"]}/>
-
-        <p className="f6 lh-copy">Additional Comments </p>
-        <textarea
-          type="TEXT"
-          name="comment"
-          id="comment"
-          value={this.state.receipt.comment}
-          onChange = {this.handleChange}
-        />
-
-        <p>
-          <button className="record-button" onClick={this.handleSubmit}>
+          <FormError error={this.state.errors["transaction_type"]}/>
+          { this.renderRentalDates() }
+          <h5>Purchase Date</h5>
+          <input
+            type="date"
+            name="purchase_date"
+            value={this.state.receipt.purchase_date}
+            onChange={this.handleChange}
+            className="textinput"
+          />
+          <FormError error={this.state.errors["purchase_date"]}/>
+          <h5>Additional Comments</h5>
+          <textarea
+            type="TEXT"
+            name="comment"
+            id="comment"
+            rows={4}
+            value={this.state.receipt.comment}
+            onChange={this.handleChange}
+            className="textarea"
+          />
+          <Button type="button-primary" className="w4" color="ochre" onClick={this.handleSubmit}>
             Record
-          </button>
-        </p>
+          </Button>
+        </div>
       </div>
     );
   }

--- a/app/javascript/components/requests/Receipt.jsx
+++ b/app/javascript/components/requests/Receipt.jsx
@@ -48,13 +48,18 @@ class Receipt extends React.Component {
     const id = request.id;
     return (
         <div className = "w100">
-          <StyledModal title="EDIT RECEIPT" color="ochre">
+          <StyledModal
+            title="EDIT"
+            color="ochre"
+            buttonType="hover-button"
+          >
             <TransactionForm
               artist={this.props.artist}
               request_id={id}
               receipt={request.receipt}
               route={APIRoutes.receipts.update(request.receipt.id)}
               method="PATCH"
+              work={this.state.request.work}
             />
           </StyledModal>
         </div>
@@ -68,19 +73,18 @@ class Receipt extends React.Component {
     const closed_timestamps = new Date(request.updated_at).toLocaleDateString();
 
     return (
-<div key={request.id} className="request bg-white mb3">
-  <div className="fl w-25">
-    <WorkFixedPanel work={request.work}/>
-  </div>
-  <div className="fl w-75 pa3 request-wrapper">
-    <div className="request-container w-100">
-      {
-        this.props.artist ? (
+      <div key={request.id} className="request bg-white mb3">
+        <div className="fl w-25">
+          <WorkFixedPanel work={request.work}/>
+        </div>
+        <div className="fl w-75 pa3 request-wrapper">
+          <div className="request-container w-100">
+            {
+              this.props.artist ? (
                 <div className="request-action">
                   <BuyerSnapshot buyer={this.state.request.buyer} />
                   <div className = "w5">
                     <p className = "closed-request-button pa3"> You completed this request on {closed_timestamps} </p>
-                    {this.renderEditReceipt()}
                   </div>
                 </div>
               ) : (
@@ -92,7 +96,10 @@ class Receipt extends React.Component {
                 </div>
               )
             }
-            <div className="attr-container pa3 mt2">
+            <div className="attr-container pa3 mt2 relative">
+              <div className="overlay overlay-button">
+                {this.renderEditReceipt()}
+              </div>
               {this.getAttr(request)}
             </div>
           </div>

--- a/app/javascript/components/requests/Request.jsx
+++ b/app/javascript/components/requests/Request.jsx
@@ -83,6 +83,7 @@ class Request extends React.Component {
           <StyledModal
             title="COMPLETE"
             color="ochre"
+            buttonType="button-primary"
           >
             <TransactionForm
               artist={this.props.artist}
@@ -90,6 +91,7 @@ class Request extends React.Component {
               receipt={empty_receipt}
               route={APIRoutes.receipts.create}
               method="POST"
+              work={this.state.request.work}
             />
           </StyledModal>
         </div>


### PR DESCRIPTION
## Create Button Component, Style Form, Add Modal Styling

Button:
- Accepts types: `button-primary`, `button-secondary`, `button-tertiary`, `hover-button`
- Accepts colors (and styles types accordingly)
- Accepts `onClick` func

Modal
- Applies absolute positioning to allow for scroll on overflow
- Adds a header based on the `title` prop
- Adds functionality to close

Styles receipt form.

### Screenshots
![image](https://user-images.githubusercontent.com/29110579/49135367-571a6380-f29b-11e8-910d-b9a4e27d4bb9.png)
![image](https://user-images.githubusercontent.com/29110579/49135391-6a2d3380-f29b-11e8-9828-b2b2ff430adb.png)

CC: @clairelin135
