### PR TITLE
Loading state for editing artwork/buyer/artist profile

### DIFF
--- a/app/javascript/components/artists/AllArtists.jsx
+++ b/app/javascript/components/artists/AllArtists.jsx
@@ -64,7 +64,7 @@ class AllArtists extends React.Component {
   render() {
     if (!this.state.componentDidMount) {
       return (
-        <div><LoadingOverlay itemType="artists" /></div>
+        <div><LoadingOverlay itemType="artists" fullPage={true} /></div>
       );
     }
 
@@ -72,7 +72,7 @@ class AllArtists extends React.Component {
 
     return (
       <div className="pt4">
-        {this.state.isLoading ? <LoadingOverlay itemType="artists" /> : null}
+        {this.state.isLoading ? <LoadingOverlay itemType="artists" fullPage={true} /> : null}
         <div className="fl w-20 pa3 mt5">
           <Filters
             ref={(node) => { this.filters = node }}

--- a/app/javascript/components/artists/UpdateArtist.jsx
+++ b/app/javascript/components/artists/UpdateArtist.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types"
 import React from 'react';
 import Button from "../helpers/Button";
 import FormError from "../helpers/FormError";
+import LoadingOverlay from "../helpers/LoadingOverlay";
 import { convertSnakeCase } from "../../utils/snake_case";
 
 class UpdateArtist extends React.Component {
@@ -14,6 +15,7 @@ class UpdateArtist extends React.Component {
       categories: {},
       componentDidMount: false,
       apiFetchError: false,
+      updatingArtist: false,
       avatar: null,
       errors: {
         name: "",
@@ -99,6 +101,7 @@ class UpdateArtist extends React.Component {
     if (hasErrors) {
       this.setState({ errors: errors });
     } else {
+      this.setState({ updatingArtist: true })
       event.preventDefault();
       let formData = new FormData();
       const formKeys = ['name', 'program', 'media', 'description', 'featured_work_id'];
@@ -136,14 +139,15 @@ class UpdateArtist extends React.Component {
       )
     }
     if (!this.state.componentDidMount) {
-      return (
-        <div><h2>Loading</h2></div>
-      )
+      return <LoadingOverlay itemType="information" fullPage={true} />;
     }
+
+    let formLoadingOverlay = this.state.updatingArtist ? <LoadingOverlay /> : null;
     return (
       <div className="mw6 center">
         <h1>UPDATE ARTIST</h1>
-        <div className="bg-white pa3">
+        <div className="bg-white pa3 relative">
+          {formLoadingOverlay}
           <h5>Name</h5>
           <input
             value={this.state.artist.name}

--- a/app/javascript/components/buyers/UpdateBuyer.jsx
+++ b/app/javascript/components/buyers/UpdateBuyer.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types"
 import React from 'react';
 import Button from "../helpers/Button";
 import FormError from "../helpers/FormError";
+import LoadingOverlay from "../helpers/LoadingOverlay";
 
 class UpdateBuyer extends React.Component {
   constructor(props) {
@@ -11,6 +12,7 @@ class UpdateBuyer extends React.Component {
       buyer: {},
       avatar: null,
       componentDidMount: false,
+      updatingBuyer: false,
       errors : {
         name: "",
         phone_number: ""
@@ -83,6 +85,7 @@ class UpdateBuyer extends React.Component {
       this.setState({ errors: errors });
     } else {
       event.preventDefault();
+      this.setState({ updatingBuyer: true });
       let formData = new FormData();
       formData.append('buyer[name]', this.state.buyer.name);
       formData.append('buyer[phone_number]', this.state.buyer.phone_number);
@@ -114,13 +117,16 @@ class UpdateBuyer extends React.Component {
   render() {
     if (!this.state.componentDidMount) {
       return (
-        <div><h2>Loading</h2></div>
+        <LoadingOverlay itemType="information" fullPage={true} />
       );
     }
+
+    let formLoadingOverlay = this.state.updatingBuyer ? <LoadingOverlay /> : null;
     return (
       <div className="mw6 center">
         <h1>UPDATE BUYER</h1>
-        <div className="bg-white pa3">
+        <div className="bg-white pa3 relative">
+          {formLoadingOverlay}
           <h5>Name</h5>
           <input
             value={this.state.buyer.name}

--- a/app/javascript/components/commissions/Commission.jsx
+++ b/app/javascript/components/commissions/Commission.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import BuyerSnapshot from "../buyers/BuyerSnapshot";
+import LoadingOverlay from "../helpers/LoadingOverlay";
 
 class Commission extends React.Component {
   constructor(props) {
@@ -46,9 +47,7 @@ class Commission extends React.Component {
 
   render() {
     if (!this.state.componentDidMount) {
-      return (
-        <div><h2>Loading</h2></div>
-      );
+      return <LoadingOverlay fullPage={true} />;
     }
     return (
       <div className="mw7 center">

--- a/app/javascript/components/commissions/CommissionsForm.jsx
+++ b/app/javascript/components/commissions/CommissionsForm.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import Panel from "../helpers/Panel";
 import FormError from "../helpers/FormError";
+import LoadingOverlay from "../helpers/LoadingOverlay";
 
 class CommissionsForm extends React.Component {
   constructor(props) {
@@ -17,6 +18,7 @@ class CommissionsForm extends React.Component {
         commission_type: "",
         login: ""
       },
+      updatingCommission: false,
       componentDidMount: false
     }
   }
@@ -43,6 +45,7 @@ class CommissionsForm extends React.Component {
     if (hasErrors) {
       this.setState({ errors: errors });
     } else {
+      this.setState({ updatingCommission: true })
       const artist_id = this.props.artist.id;
       const buyer_id = this.props.buyer.id;
       const commissions_route = APIRoutes.commissions.create;
@@ -96,6 +99,7 @@ class CommissionsForm extends React.Component {
         color="indigo"
         title="Contact the Artist"
       >
+        {this.state.updatingCommission ? <LoadingOverlay /> : null}
         <h5>Inquiry Type</h5>
         <FormError error={this.state.errors["commission_type"]}/>
         <select

--- a/app/javascript/components/helpers/LoadingOverlay.jsx
+++ b/app/javascript/components/helpers/LoadingOverlay.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
+import classNames from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleNotch } from "@fortawesome/free-solid-svg-icons";
 
@@ -19,11 +20,12 @@ class LoadingOverlay extends React.Component {
   }
 
   render() {
-      <div 
-        className={classNames(
+      return (
+        <div 
+          className={classNames(
           "w-100 bg-snow pa2 pt3 pb3 z-1 bg-white-90 top-0 bottom-0 left-0 flex flex-column justify-center items-center",
           this.props.fullPage ? "fixed" : "absolute")}
-      >
+        >
         <FontAwesomeIcon className="gray" icon={faCircleNotch} size="3x" spin/>
         <p className="mt3 f3 i gray">Loading {this.props.itemType}</p>
       </div>

--- a/app/javascript/components/helpers/LoadingOverlay.jsx
+++ b/app/javascript/components/helpers/LoadingOverlay.jsx
@@ -15,14 +15,15 @@ class LoadingOverlay extends React.Component {
 
   static propTypes = {
     fullPage: PropTypes.bool,
+    itemType: PropTypes.string,
   }
 
   render() {
-    let classes = ("w-100 bg-snow pa2 pt3 pb3 z-1 bg-white-90 top-0 bottom-0 left-0 flex flex-column justify-center items-center ");
-    classes += (this.props.fullPage ? "fixed" : "absolute");
-
-    return (
-      <div className={classes}>
+      <div 
+        className={classNames(
+          "w-100 bg-snow pa2 pt3 pb3 z-1 bg-white-90 top-0 bottom-0 left-0 flex flex-column justify-center items-center",
+          this.props.fullPage ? "fixed" : "absolute")}
+      >
         <FontAwesomeIcon className="gray" icon={faCircleNotch} size="3x" spin/>
         <p className="mt3 f3 i gray">Loading {this.props.itemType}</p>
       </div>

--- a/app/javascript/components/helpers/LoadingOverlay.jsx
+++ b/app/javascript/components/helpers/LoadingOverlay.jsx
@@ -5,6 +5,7 @@ import { faCircleNotch } from "@fortawesome/free-solid-svg-icons";
 
 /**
  * @prop itemType: Displays loading animation overlay
+ * @prop fullPage: Sets loading overlay to expand over entire window
  */
 class LoadingOverlay extends React.Component {
   constructor(props) {
@@ -12,17 +13,19 @@ class LoadingOverlay extends React.Component {
     this.state = {};
   }
 
+  static propTypes = {
+    fullPage: PropTypes.bool,
+  }
+
   render() {
-    if (this.props.itemType) {
-      return (
-        <div className="w-100 bg-snow pa2 pt3 pb3 fixed z-1 bg-white-90 top-0 bottom-0 flex flex-column justify-center items-center">
-          <FontAwesomeIcon className="gray" icon={faCircleNotch} size="3x" spin/>
-          <p className="mt3 f3 i gray">Loading {this.props.itemType}</p>
-        </div>
-      );
-    }
+    let classes = ("w-100 bg-snow pa2 pt3 pb3 z-1 bg-white-90 top-0 bottom-0 left-0 flex flex-column justify-center items-center ");
+    classes += (this.props.fullPage ? "fixed" : "absolute");
+
     return (
-      <div />
+      <div className={classes}>
+        <FontAwesomeIcon className="gray" icon={faCircleNotch} size="3x" spin/>
+        <p className="mt3 f3 i gray">Loading {this.props.itemType}</p>
+      </div>
     );
   }
 }

--- a/app/javascript/components/helpers/Panel.jsx
+++ b/app/javascript/components/helpers/Panel.jsx
@@ -18,7 +18,7 @@ class Panel extends React.Component {
         <div className={"header-bar pl3 pr3 pt2 pb2 bg-" + this.props.color}>
           <h5 className="white mb0">{this.props.title}</h5>
         </div>
-        <div className="panel-container pa3 bg-white">
+        <div className="panel-container pa3 bg-white relative">
           {this.props.children}
         </div>
       </div>

--- a/app/javascript/components/receipts/TransactionForm.jsx
+++ b/app/javascript/components/receipts/TransactionForm.jsx
@@ -4,6 +4,7 @@ import FormError from '../helpers/FormError';
 import { convertToCurrency } from "../../utils/currency";
 import WorkFixedPanel from "../works/WorkFixedPanel";
 import Button from "../helpers/Button";
+import LoadingOverlay from "../helpers/LoadingOverlay";
 
 /**
 * @prop artist: artist creating transaction
@@ -152,9 +153,7 @@ class TransactionForm extends React.Component {
 
   render() {
     if (!this.state.didMount) {
-      return (
-        <div><h2>Loading</h2></div>
-      );
+      return <LoadingOverlay fullPage={true} />;
     }
     return (
       <div className="w-100">

--- a/app/javascript/components/receipts/TransactionForm.jsx
+++ b/app/javascript/components/receipts/TransactionForm.jsx
@@ -19,7 +19,6 @@ class TransactionForm extends React.Component {
       route: this.props.route,
       method: this.props.method,
       types: {},
-      didMount: false,
       errors: {
         transaction_type: '',
         purchase_date: '',
@@ -114,7 +113,6 @@ class TransactionForm extends React.Component {
       response => {
         this.setState({
           types: response,
-          didMount: true
         });
       },
       error => {

--- a/app/javascript/components/receipts/TransactionForm.jsx
+++ b/app/javascript/components/receipts/TransactionForm.jsx
@@ -4,6 +4,7 @@ import FormError from '../helpers/FormError';
 import { convertToCurrency } from "../../utils/currency";
 import WorkFixedPanel from "../works/WorkFixedPanel";
 import Button from "../helpers/Button";
+import LoadingOverlay from "../helpers/LoadingOverlay";
 
 /**
 * @prop artist: artist creating transaction
@@ -19,6 +20,7 @@ class TransactionForm extends React.Component {
       route: this.props.route,
       method: this.props.method,
       types: {},
+      updatingTransaction: false,
       errors: {
         transaction_type: '',
         purchase_date: '',
@@ -87,6 +89,7 @@ class TransactionForm extends React.Component {
     if (hasErrors) {
       this.setState({ errors: errors });
     } else if (method == "POST") {
+      this.setState({ updatingTransaction: true });
       Requester.post(receipts_route, payload).then(
         response => {
           window.location.href = '/requests';
@@ -96,6 +99,7 @@ class TransactionForm extends React.Component {
         }
       )
     } else {
+      this.setState({ updatingTransaction: true });
       Requester.update(receipts_route, payload).then(
         response => {
           window.location.href = '/requests';
@@ -151,6 +155,7 @@ class TransactionForm extends React.Component {
   render() {
     return (
       <div className="w-100">
+        {this.state.updatingTransaction ? <LoadingOverlay /> : null}
         <div className="fl w-30">
           <WorkFixedPanel work={this.props.work}/>
         </div>

--- a/app/javascript/components/receipts/TransactionForm.jsx
+++ b/app/javascript/components/receipts/TransactionForm.jsx
@@ -4,7 +4,6 @@ import FormError from '../helpers/FormError';
 import { convertToCurrency } from "../../utils/currency";
 import WorkFixedPanel from "../works/WorkFixedPanel";
 import Button from "../helpers/Button";
-import LoadingOverlay from "../helpers/LoadingOverlay";
 
 /**
 * @prop artist: artist creating transaction
@@ -152,9 +151,6 @@ class TransactionForm extends React.Component {
   }
 
   render() {
-    if (!this.state.didMount) {
-      return <LoadingOverlay fullPage={true} />;
-    }
     return (
       <div className="w-100">
         <div className="fl w-30">

--- a/app/javascript/components/requests/RequestForm.jsx
+++ b/app/javascript/components/requests/RequestForm.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import Panel from '../helpers/Panel';
 import FormError from '../helpers/FormError';
+import LoadingOverlay from '../helpers/LoadingOverlay';
 
 class RequestForm extends React.Component {
   constructor(props) {
@@ -17,6 +18,7 @@ class RequestForm extends React.Component {
         message: "",
         login: ""
       },
+      updatingRequest: false,
       componentDidMount: false
     }
   }
@@ -51,6 +53,7 @@ class RequestForm extends React.Component {
     if (hasErrors) {
       this.setState({ errors: errors });
     } else {
+      this.setState({ updatingRequest: true })
       const requests_route = APIRoutes.requests.create;
       let payload = this.state.request;
       payload["buyer_id"] = this.props.buyer.id;
@@ -110,6 +113,7 @@ class RequestForm extends React.Component {
           color="magenta"
           title="Request Artwork"
         >
+        {this.state.updatingRequest ? <LoadingOverlay /> : null}
           <h5>Request Type</h5>
           <select
             name="types"

--- a/app/javascript/components/requests/UserRequests.jsx
+++ b/app/javascript/components/requests/UserRequests.jsx
@@ -4,6 +4,7 @@ import Request from "./Request";
 import Receipt from "./Receipt";
 import None from "../helpers/None";
 import classNames from "classnames";
+import LoadingOverlay from "../helpers/LoadingOverlay";
 
 class UserRequests extends React.Component {
   constructor(props) {
@@ -126,9 +127,7 @@ class UserRequests extends React.Component {
 
   render() {
     if (!this.state.componentDidMount) {
-      return (
-        <div><h2>Loading</h2></div>
-      );
+      return <LoadingOverlay fullPage={true} />;
     }
     return (
       <div className="mw8 center">

--- a/app/javascript/components/works/UpdateWork.jsx
+++ b/app/javascript/components/works/UpdateWork.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types"
 import React from 'react';
 import WorkForm from './WorkForm.jsx';
-import LodaingOverlay from '../helpers/LodaingOverlay.jsx'
+import LodaingOverlay from '../helpers/LoadingOverlay.jsx'
 
 class UpdateWork extends React.Component {
   constructor(props) {
@@ -28,11 +28,8 @@ class UpdateWork extends React.Component {
 
   render() {
     if (!this.state.componentDidMount) {
-      return (
-        <div><h2>Loading</h2></div>
-      );
+      return <LoadingOverlay fullPage={true} />;
     }
-    return (
       <div className="mw6 center pt3">
         <h1>Update Work</h1>
         <WorkForm

--- a/app/javascript/components/works/UpdateWork.jsx
+++ b/app/javascript/components/works/UpdateWork.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types"
 import React from 'react';
 import WorkForm from './WorkForm.jsx';
+import LodaingOverlay from '../helpers/LodaingOverlay.jsx'
 
 class UpdateWork extends React.Component {
   constructor(props) {
@@ -8,7 +9,8 @@ class UpdateWork extends React.Component {
 
     this.state = {
       work: null,
-      componentDidMount: false
+      componentDidMount: false,
+      updatingWork: false
     }
   }
 

--- a/app/javascript/components/works/UpdateWork.jsx
+++ b/app/javascript/components/works/UpdateWork.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types"
 import React from 'react';
-import WorkForm from './WorkForm.jsx';
-import LodaingOverlay from '../helpers/LoadingOverlay.jsx'
+import WorkForm from "./WorkForm";
+import LoadingOverlay from "../helpers/LoadingOverlay";
 
 class UpdateWork extends React.Component {
   constructor(props) {
@@ -30,6 +30,7 @@ class UpdateWork extends React.Component {
     if (!this.state.componentDidMount) {
       return <LoadingOverlay fullPage={true} />;
     }
+    return (
       <div className="mw6 center pt3">
         <h1>Update Work</h1>
         <WorkForm

--- a/app/javascript/components/works/WorkForm.jsx
+++ b/app/javascript/components/works/WorkForm.jsx
@@ -4,6 +4,7 @@ import Dropzone from "react-dropzone";
 import UploadThumbnail from "./UploadThumbnail";
 import update from 'immutability-helper';
 import FormError from '../helpers/FormError';
+import LoadingOverlay from '../helpers/LoadingOverlay';
 import { convertSnakeCase } from "../../utils/snake_case";
 
 class WorkForm extends React.Component {
@@ -15,6 +16,7 @@ class WorkForm extends React.Component {
       method: this.props.method,
       categories: null,
       componentDidMount: false,
+      updatingWork: false,
       uploads: [],
       attachmentsToDelete: [],
       errors: {
@@ -118,6 +120,7 @@ class WorkForm extends React.Component {
     if (hasErrors) {
       this.setState({ errors: errors });
     } else {
+      this.setState({ updatingWork: true });
       let formData = new FormData();
       const formKeys = ['artist_id', 'title', 'material', 'media', 'availability', 'description', 'featured_image'];
       formKeys.forEach(key => {
@@ -198,11 +201,14 @@ class WorkForm extends React.Component {
   render() {
     if (!this.state.componentDidMount) {
       return (
-        <div><h2>Loading</h2></div>
+        <LoadingOverlay itemType="form" fullPage={true} />
       )
     }
+
+    let formLoadingOverlay = (this.state.updatingWork ? <LoadingOverlay /> : null);
     return (
-      <div className="bg-white pa3">
+      <div className="bg-white pa3 relative">
+        {formLoadingOverlay}
         <h5>Title</h5>
         <input
           value={this.state.work.title}

--- a/app/javascript/components/works/Works.jsx
+++ b/app/javascript/components/works/Works.jsx
@@ -58,7 +58,7 @@ class Works extends React.Component {
     const { filters, works } = this.state;
     return (
       <div className="pt4">
-        {this.state.isLoading ? <LoadingOverlay itemType="artwork" /> : null}
+        {this.state.isLoading ? <LoadingOverlay itemType="artwork" fullPage={true} /> : null}
         <div className="fl w-20 pa3 mt5">
           <Filters
             ref={(node) => { this.filters = node }}


### PR DESCRIPTION
## Loading state for editing artwork/buyer/artist profile
[Asana Ticket](https://app.asana.com/0/860297512787618/1110722831522308/f)
* Added form loading overlay upon form submission
* Added `fullPage` prop to `LoadingOverlay` for full page overlays vs local (ie within the form)
* Added `LoadingOverlay` to more full page locations

### Related PRs
Loading Bars: https://github.com/calblueprint/SFAI/pull/59 

### Migrations
None

### Tests Performed, Edge Cases
None

### Screenshots
<img width="777" alt="screen shot 2019-02-26 at 10 41 06 am" src="https://user-images.githubusercontent.com/23442055/53438043-d0694580-39b3-11e9-98de-c78955685a6f.png">

CC: @by-co 
