### PR TITLE
Restyle account login/signup pages

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -33,10 +33,6 @@
      padding-top: 64px;
  }
 
- body {
-    background-color: $snow;
- }
-
 .mt-auto {
     margin-top: auto; // aligns button to bottom of div
 }

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -37,6 +37,7 @@
 		color: inherit;
 		display: inline-block;
 		text-decoration: none;
+		font-weight: normal;
 
 		&:hover {
 			text-decoration: underline;

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -97,7 +97,6 @@ input[type="checkbox"] {
 .textinput {
   @extend .pl2;
   @extend .row-input;
-  border-style: none;
   box-sizing: border-box;
   height: 2.5rem;
 }

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -91,25 +91,29 @@ input[type="checkbox"] {
   @extend .mt2;
   @extend .mb2;
   @extend .w-100;
+  outline: none;
 }
 
 .textinput {
   @extend .pl2;
   @extend .row-input;
-  outline: none;
-  height: 45px;
+  border-style: none;
   box-sizing: border-box;
+  height: 2.5rem;
+}
+
+.texthelp {
+  @extend .f6;
+  color: $gray;
 }
 
 .input-dropdown {
-  height: 45px;
   @extend .row-input;
-  outline: none;
+  height: 2rem;
 }
 
 .textarea {
   @extend .row-input;
-  outline: none;
   @extend .pa2;
 }
 

--- a/app/assets/stylesheets/pages/Login.scss
+++ b/app/assets/stylesheets/pages/Login.scss
@@ -12,42 +12,11 @@
     form {
       margin: 36px 0;
     }
-
-    .field>label, .label {
-      font-family: $font;
-      display: block;
-      margin-bottom: 18px;
-    }
-
-    div.field {
-      margin-bottom: 24px;
-    }
-
-    input.field {
-      border-style: none;
-      padding: 0 12px;
-      height: 48px;
-      width: 100%;
-    }
-
-    label.inline {
-      display: inline-block;
-      margin-bottom: 0;
-    }
-
-    .button {
-      width: 100%;
-      height: 48px;
-      background-color: $charcoal;
-      color: $white;
-      text-transform: uppercase;
-      font-family: $font;
-    }
-
   }
-
   a {
-    color: $gray;
-    margin-right: 12px;
+    @extend .mustard;
+    &:hover {
+			text-decoration: underline;
+		}
   }
 }

--- a/app/assets/stylesheets/pages/Login.scss
+++ b/app/assets/stylesheets/pages/Login.scss
@@ -19,4 +19,13 @@
 			text-decoration: underline;
 		}
   }
+  input[type="checkbox"] {
+    &:after {
+      background-color: $white;
+    }
+
+    &:checked:after {
+      background-color: $mustard;
+    }
+  }
 }

--- a/app/assets/stylesheets/pages/Login.scss
+++ b/app/assets/stylesheets/pages/Login.scss
@@ -19,6 +19,10 @@
 			text-decoration: underline;
 		}
   }
+  input {
+    border-style: none;
+  }
+  
   input[type="checkbox"] {
     &:after {
       background-color: $white;

--- a/app/assets/stylesheets/partials/_fonts.scss
+++ b/app/assets/stylesheets/partials/_fonts.scss
@@ -62,3 +62,10 @@ h6 {
 	font-size: 12px;
 	color: $gray;
 }
+
+a {
+	display: block;
+	font-size: 16px;
+	font-weight: bold;
+	text-decoration: none;
+}

--- a/app/views/artists/confirmations/new.html.erb
+++ b/app/views/artists/confirmations/new.html.erb
@@ -12,9 +12,7 @@
       </div>
 
       <div class="flex justify-between">
-        <div class="flex flex-column justify-around">
-          <%= render "artists/shared/links" %>
-        </div>
+        <%= render "artists/shared/links" %>
         <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>

--- a/app/views/artists/confirmations/new.html.erb
+++ b/app/views/artists/confirmations/new.html.erb
@@ -5,7 +5,7 @@
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="mb3">
+      <div class="mb4">
         <%= f.label :email, class: "label" %>
         <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
         <p class="texthelp"> artists.sfai.edu required </p>

--- a/app/views/artists/confirmations/new.html.erb
+++ b/app/views/artists/confirmations/new.html.erb
@@ -8,7 +8,7 @@
       <div class="mb4">
         <%= f.label :email, class: "label" %>
         <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-        <p class="texthelp"> artists.sfai.edu required </p>
+        <p class="texthelp"> artists.sfai.edu email required </p>
       </div>
 
       <div class="flex justify-between">

--- a/app/views/artists/confirmations/new.html.erb
+++ b/app/views/artists/confirmations/new.html.erb
@@ -1,23 +1,22 @@
 <div class="loginPage">
   <div class="container">
-    <h1>Resend confirmation instructions</h1>
+    <h1>Resend Confirmation</h1>
 
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="field">
-        <%= f.label :email, class: "label" %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+      <div class="mb3">
+        <%= f.label :email, class: "label" %>
+        <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+        <p class="texthelp"> artists.sfai.edu required </p>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Resend confirmation", class: "button" %>
+      <div class="flex justify-between">
+        <div class="flex flex-column justify-around">
+          <%= render "artists/shared/links" %>
+        </div>
+        <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <br /><br />
-    <%= render "artists/shared/links" %>
   </div>
 </div>

--- a/app/views/artists/passwords/edit.html.erb
+++ b/app/views/artists/passwords/edit.html.erb
@@ -6,30 +6,23 @@
       <%= devise_error_messages! %>
       <%= f.hidden_field :reset_password_token %>
 
-      <div class="field">
-        <%= f.label :password, "New password" %><br />
+      <div class="mb3">
+        <%= f.label :password %>
+        <%= f.password_field :password, class: "textinput w-100", autofocus: true, autocomplete: "new-password" %>
         <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %> characters minimum)</em><br /><br />
+          <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
         <% end %>
-        <%= f.password_field :password, class: "field", autofocus: true, autocomplete: "new-password" %>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="field">
-        <%= f.label :password_confirmation, "Confirm new password" %><br /><br />
-        <%= f.password_field :password_confirmation, class: "field", autocomplete: "off" %>
+      <div class="mb4">
+        <%= f.label :password_confirmation, "Confirm new password" %>
+        <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "off" %>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Change my password", class: "button" %>
+      <div class="flex justify-between">
+        <%= render "artists/shared/links" %>
+        <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <br /><br />
-
-    <%= render "artists/shared/links" %>
   </div>
 </div>

--- a/app/views/artists/passwords/new.html.erb
+++ b/app/views/artists/passwords/new.html.erb
@@ -11,11 +11,10 @@
       </div>
 
       <div class="flex justify-between">
-        <div class="flex flex-column justify-around">
-          <%= render "artists/shared/links" %>
-        </div>
+        <%= render "artists/shared/links" %>
         <%= f.submit "submit", class: "button-primary bg-mustard w4" %>
       </div>
+
     <% end %>
   </div>
 </div>

--- a/app/views/artists/passwords/new.html.erb
+++ b/app/views/artists/passwords/new.html.erb
@@ -4,7 +4,7 @@
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
-      <div class="mb3">
+      <div class="mb4">
         <%= f.label :email %>
         <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email" %>
         <p class="texthelp"> artists.sfai.edu required </p>

--- a/app/views/artists/passwords/new.html.erb
+++ b/app/views/artists/passwords/new.html.erb
@@ -7,7 +7,7 @@
       <div class="mb4">
         <%= f.label :email %>
         <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email" %>
-        <p class="texthelp"> artists.sfai.edu required </p>
+        <p class="texthelp"> artists.sfai.edu email required </p>
       </div>
 
       <div class="flex justify-between">

--- a/app/views/artists/passwords/new.html.erb
+++ b/app/views/artists/passwords/new.html.erb
@@ -1,24 +1,21 @@
 <div class="loginPage">
   <div class="container">
-    <h1>Forgot your password?</h1>
+    <h1>Reset password</h1>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
-
-      <div class="field">
-        <%= f.label :email %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+      <div class="mb3">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> artists.sfai.edu required </p>
       </div>
 
-      <br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Reset Password", class: "button" %>
+      <div class="flex justify-between">
+        <div class="flex flex-column justify-around">
+          <%= render "artists/shared/links" %>
+        </div>
+        <%= f.submit "submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <br /><br />
-
-    <%= render "artists/shared/links" %>
   </div>
 </div>

--- a/app/views/artists/registrations/edit.html.erb
+++ b/app/views/artists/registrations/edit.html.erb
@@ -1,55 +1,51 @@
 <div class="loginPage">
   <div class="container">
-    <h1>Edit Artist</h1>
+    <h1>Edit Account</h1>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="field">
-        <%= f.label :email %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+      <div class="mb3">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> artists.sfai.edu email required </p>
       </div>
-
-      <br /><br /><br />
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
         <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
       <% end %>
 
-      <div class="field">
-        <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br /><br />
-        <%= f.password_field :password, class: "field", autocomplete: "new-password" %>
-        <% if @minimum_password_length %>
-          <br />
-          <em><%= @minimum_password_length %> characters minimum</em>
-        <% end %>
+      <div class="mb3">
+          <%= f.label :password %> <i>(leave blank if you don't want to change it)</i>
+          <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password" %>
+          <% if @minimum_password_length %>
+            <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
+          <% end %>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="field">
-        <%= f.label :password_confirmation %><br />
-        <%= f.password_field :password_confirmation, class: "field", autocomplete: "new-password" %>
+      <div class="mb3">
+        <%= f.label :password_confirmation %>
+        <%= f.password_field :password_confirmation, class: "textinput", autocomplete: "new-password" %>
       </div>
 
-      <br /><br />
-
-      <div class="field">
-        <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-        <%= f.password_field :current_password, class: "field", autocomplete: "current-password" %>
+      <div class="mb4">
+        <%= f.label :current_password %>*
+        <%= f.password_field :current_password, class: "textinput", autocomplete: "current-password" %>
+        <p class="texthelp"> * required </p>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Update", class: "button" %>
+      
+      <div class="flex justify-end">
+        <%= f.submit "Update", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
 
-    <br/><br/>
+    <h3>Delete Account</h3>
+    <p>WARNING: This will permanently delete your account and all associated data.</p>
+    <div class="flex justify-end">
+      <%= button_to "Delete", registration_path(resource_name), data: { confirm: "Are you sure?" },
+          method: :delete, class: "button-primary bg-gray hover-bg-red w4" %>
+    </div>
 
-    <h3>Cancel my account</h3>
-
-    <p>Unhappy?<br/><br/> <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
   </div>
 </div>

--- a/app/views/artists/registrations/new.html.erb
+++ b/app/views/artists/registrations/new.html.erb
@@ -8,7 +8,7 @@
       <div class="mb3">
         <%= f.label :email %>
         <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
-        <p class="texthelp"> artists.sfai.edu required </p>
+        <p class="texthelp"> artists.sfai.edu email required </p>
       </div>
 
       <div class="mb3">

--- a/app/views/artists/registrations/new.html.erb
+++ b/app/views/artists/registrations/new.html.erb
@@ -5,31 +5,31 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="field">
+      <div class="mb3">
         <%= f.label :email %>
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> artists.sfai.edu required </p>
       </div>
 
-      <div class="field">
-        <div class="label">
+      <div class="mb3">
           <%= f.label :password %>
+          <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password" %>
           <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %> characters minimum)</em>
+            <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
           <% end %>
+      </div>
+
+      <div class="mb3">
+        <%= f.label :password_confirmation, class: "mb1" %>
+        <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password" %>
+      </div>
+
+      <div class="flex justify-between">
+        <div class="flex flex-column justify-around">
+        <%= render "artists/shared/links" %>
         </div>
-        <%= f.password_field :password, class: "field", autocomplete: "new-password" %>
-      </div>
-
-      <div class="field">
-        <%= f.label :password_confirmation %>
-        <%= f.password_field :password_confirmation, class: "field", autocomplete: "new-password" %>
-      </div>
-
-      <div class="actions">
-        <%= f.submit "Sign up", class: "button" %>
+        <%= f.submit "Sign up", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <%= render "artists/shared/links" %>
   </div>
 </div>

--- a/app/views/artists/registrations/new.html.erb
+++ b/app/views/artists/registrations/new.html.erb
@@ -19,7 +19,7 @@
           <% end %>
       </div>
 
-      <div class="mb3">
+      <div class="mb4">
         <%= f.label :password_confirmation, class: "mb1" %>
         <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password" %>
       </div>

--- a/app/views/artists/registrations/new.html.erb
+++ b/app/views/artists/registrations/new.html.erb
@@ -25,9 +25,7 @@
       </div>
 
       <div class="flex justify-between">
-        <div class="flex flex-column justify-around">
         <%= render "artists/shared/links" %>
-        </div>
         <%= f.submit "Sign up", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>

--- a/app/views/artists/sessions/new.html.erb
+++ b/app/views/artists/sessions/new.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <% if devise_mapping.rememberable? -%>
-        <div class="mb3">
+        <div class="mb4">
           <%= f.check_box :remember_me %>
           <%= f.label :remember_me %>
         </div>

--- a/app/views/artists/sessions/new.html.erb
+++ b/app/views/artists/sessions/new.html.erb
@@ -26,9 +26,7 @@
       <% end -%>
 
       <div class="flex justify-between">
-        <div class="flex flex-column justify-around">
-          <%= render "buyers/shared/links" %>
-        </div>
+        <%= render "artists/shared/links" %>
         <%= f.submit "Log in", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>

--- a/app/views/artists/sessions/new.html.erb
+++ b/app/views/artists/sessions/new.html.erb
@@ -6,28 +6,30 @@
         <% flash.each do |key, value| %>
            <div class="flash <%= key %>"><%= value %></div>
         <% end %>
-      <div class="field">
+
+      <div class="mb3">
         <%= f.label :email %>
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> artists.sfai.edu required </p>
       </div>
 
-      <div class="field">
-        <%= f.label :password %>
-        <%= f.password_field :password, class: "field", autocomplete: "current-password" %>
+      <div class="mb3">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: "textinput w-100", autocomplete: "current-password" %>
       </div>
 
-      <% if devise_mapping.rememberable? %>
-        <div class="field">
+      <% if devise_mapping.rememberable? -%>
+        <div class="mb3">
           <%= f.check_box :remember_me %>
-          <%= f.label :remember_me, class: "inline" %>
+          <%= f.label :remember_me %>
         </div>
-      <% end %>
+      <% end -%>
 
-      <div class="actions">
-        <%= f.submit "Log in", class: "button" %>
+      <div class="flex justify-between">
+        <div class="flex flex-column justify-around">
+          <%= render "buyers/shared/links" %>
+        </div>
+        <%= f.submit "Log in", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-    
-    <%= render "artists/shared/links" %>
-  </div>
 </div>

--- a/app/views/artists/sessions/new.html.erb
+++ b/app/views/artists/sessions/new.html.erb
@@ -10,7 +10,7 @@
       <div class="mb3">
         <%= f.label :email %>
         <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
-        <p class="texthelp"> artists.sfai.edu required </p>
+        <p class="texthelp"> artists.sfai.edu email required </p>
       </div>
 
       <div class="mb3">

--- a/app/views/artists/shared/_links.html.erb
+++ b/app/views/artists/shared/_links.html.erb
@@ -1,3 +1,4 @@
+<div class="flex flex-column justify-around">
 <%- if controller_name != 'sessions' %>
   <%= link_to "Log in »", new_session_path(resource_name) %>
 <% end -%>
@@ -23,3 +24,4 @@
     <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %>
   <% end -%>
 <% end -%>
+</div>

--- a/app/views/artists/shared/_links.html.erb
+++ b/app/views/artists/shared/_links.html.erb
@@ -1,9 +1,9 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %>
+  <%= link_to "Log in »", new_session_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %>
+  <%= link_to "Sign up »", new_registration_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
@@ -11,7 +11,7 @@
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %>
+  <%= link_to "Didn't receive email?", new_confirmation_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/app/views/artists/shared/_links.html.erb
+++ b/app/views/artists/shared/_links.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Log in »", new_session_path(resource_name) %>
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+<%- if devise_mapping.registerable? && controller_name == 'sessions' %>
   <%= link_to "Sign up »", new_registration_path(resource_name) %>
 <% end -%>
 

--- a/app/views/artists/unlocks/new.html.erb
+++ b/app/views/artists/unlocks/new.html.erb
@@ -5,20 +5,16 @@
     <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="field">
-        <%= f.label :email %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+      <div class="mb4">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> artists.sfai.edu email required </p>
       </div>
 
-      <br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Resend unlock instructions", class: "button" %>
+      <div class="flex justify-between">
+        <%= render "artists/shared/links" %>
+        <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <br /><br />
-
-    <%= render "artists/shared/links" %>
   </div>
 </div>

--- a/app/views/buyers/confirmations/new.html.erb
+++ b/app/views/buyers/confirmations/new.html.erb
@@ -12,9 +12,7 @@
       </div>
 
       <div class="flex justify-between">
-        <div class="flex flex-column justify-around">
-          <%= render "buyers/shared/links" %>
-        </div>
+        <%= render "buyers/shared/links" %>
         <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>

--- a/app/views/buyers/confirmations/new.html.erb
+++ b/app/views/buyers/confirmations/new.html.erb
@@ -5,7 +5,7 @@
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="mb3">
+      <div class="mb4">
         <%= f.label :email, class: "label" %>
         <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
         <p class="texthelp"> alumni.sfai.edu required </p>

--- a/app/views/buyers/confirmations/new.html.erb
+++ b/app/views/buyers/confirmations/new.html.erb
@@ -8,7 +8,7 @@
       <div class="mb4">
         <%= f.label :email, class: "label" %>
         <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-        <p class="texthelp"> alumni.sfai.edu required </p>
+        <p class="texthelp"> alumni.sfai.edu email required </p>
       </div>
 
       <div class="flex justify-between">

--- a/app/views/buyers/confirmations/new.html.erb
+++ b/app/views/buyers/confirmations/new.html.erb
@@ -13,7 +13,7 @@
 
       <div class="flex justify-between">
         <div class="flex flex-column justify-around">
-          <%= render "artists/shared/links" %>
+          <%= render "buyers/shared/links" %>
         </div>
         <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>

--- a/app/views/buyers/confirmations/new.html.erb
+++ b/app/views/buyers/confirmations/new.html.erb
@@ -1,23 +1,22 @@
 <div class="loginPage">
   <div class="container">
-    <h1>Resend confirmation instructions</h1>
+    <h1>Resend Confirmation</h1>
 
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="field">
-        <%= f.label :email, class: "label" %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+      <div class="mb3">
+        <%= f.label :email, class: "label" %>
+        <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+        <p class="texthelp"> alumni.sfai.edu required </p>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Resend confirmation instructions", class: "button" %>
+      <div class="flex justify-between">
+        <div class="flex flex-column justify-around">
+          <%= render "artists/shared/links" %>
+        </div>
+        <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <br /><br />
-    <%= render "buyers/shared/links" %>
   </div>
 </div>

--- a/app/views/buyers/passwords/edit.html.erb
+++ b/app/views/buyers/passwords/edit.html.erb
@@ -6,30 +6,23 @@
       <%= devise_error_messages! %>
       <%= f.hidden_field :reset_password_token %>
 
-      <div class="field">
-        <%= f.label :password, "New password" %><br />
+      <div class="mb3">
+        <%= f.label :password %>
+        <%= f.password_field :password, class: "textinput w-100", autofocus: true, autocomplete: "new-password" %>
         <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %> characters minimum)</em><br /><br />
+          <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
         <% end %>
-        <%= f.password_field :password, class: "field", autofocus: true, autocomplete: "new-password" %>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="field">
-        <%= f.label :password_confirmation, "Confirm new password" %><br /><br />
-        <%= f.password_field :password_confirmation, class: "field", autocomplete: "off" %>
+      <div class="mb4">
+        <%= f.label :password_confirmation, "Confirm new password" %>
+        <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "off" %>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Change my password", class: "button" %>
+      <div class="flex justify-between">
+        <%= render "buyers/shared/links" %>
+        <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <br /><br />
-
-    <%= render "buyers/shared/links" %>
   </div>
 </div>

--- a/app/views/buyers/passwords/new.html.erb
+++ b/app/views/buyers/passwords/new.html.erb
@@ -11,9 +11,7 @@
       </div>
 
       <div class="flex justify-between">
-        <div class="flex flex-column justify-around">
-          <%= render "buyers/shared/links" %>
-        </div>
+        <%= render "buyers/shared/links" %>
         <%= f.submit "submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>

--- a/app/views/buyers/passwords/new.html.erb
+++ b/app/views/buyers/passwords/new.html.erb
@@ -4,7 +4,7 @@
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
-      <div class="mb3">
+      <div class="mb4">
         <%= f.label :email %>
         <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email" %>
         <p class="texthelp"> alumni.sfai.edu required </p>

--- a/app/views/buyers/passwords/new.html.erb
+++ b/app/views/buyers/passwords/new.html.erb
@@ -7,7 +7,7 @@
       <div class="mb4">
         <%= f.label :email %>
         <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email" %>
-        <p class="texthelp"> alumni.sfai.edu required </p>
+        <p class="texthelp"> alumni.sfai.edu email required </p>
       </div>
 
       <div class="flex justify-between">

--- a/app/views/buyers/passwords/new.html.erb
+++ b/app/views/buyers/passwords/new.html.erb
@@ -1,24 +1,21 @@
 <div class="loginPage">
   <div class="container">
-    <h1>Forgot your password?</h1>
+    <h1>Reset password</h1>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
-
-      <div class="field">
-        <%= f.label :email %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+      <div class="mb3">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: "textinput", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> alumni.sfai.edu required </p>
       </div>
 
-      <br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Reset Password", class: "button" %>
+      <div class="flex justify-between">
+        <div class="flex flex-column justify-around">
+          <%= render "buyers/shared/links" %>
+        </div>
+        <%= f.submit "submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <br /><br />
-
-    <%= render "buyers/shared/links" %>
   </div>
 </div>

--- a/app/views/buyers/registrations/edit.html.erb
+++ b/app/views/buyers/registrations/edit.html.erb
@@ -1,55 +1,51 @@
 <div class="loginPage">
   <div class="container">
-    <h1>Edit Patron</h1>
+    <h1>Edit Account</h1>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="field">
-        <%= f.label :email %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+      <div class="mb3">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> alumni.sfai.edu email required </p>
       </div>
-
-      <br /><br /><br />
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
         <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
       <% end %>
 
-      <div class="field">
-        <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br /><br />
-        <%= f.password_field :password, class: "field", autocomplete: "new-password" %>
-        <% if @minimum_password_length %>
-          <br />
-          <em><%= @minimum_password_length %> characters minimum</em>
-        <% end %>
+      <div class="mb3">
+          <%= f.label :password %> <i>(leave blank if you don't want to change it)</i>
+          <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password" %>
+          <% if @minimum_password_length %>
+            <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
+          <% end %>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="field">
-        <%= f.label :password_confirmation %><br />
-        <%= f.password_field :password_confirmation, class: "field", autocomplete: "new-password" %>
+      <div class="mb3">
+        <%= f.label :password_confirmation %>
+        <%= f.password_field :password_confirmation, class: "textinput", autocomplete: "new-password" %>
       </div>
 
-      <br /><br />
-
-      <div class="field">
-        <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-        <%= f.password_field :current_password, class: "field", autocomplete: "current-password" %>
+      <div class="mb4">
+        <%= f.label :current_password %>*
+        <%= f.password_field :current_password, class: "textinput", autocomplete: "current-password" %>
+        <p class="texthelp"> * required </p>
       </div>
 
-      <br /><br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Update", class: "button" %>
+      
+      <div class="flex justify-end">
+        <%= f.submit "Update", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
 
-    <br/><br/>
+    <h3>Delete Account</h3>
+    <p>WARNING: This will permanently delete your account and all associated data.</p>
+    <div class="flex justify-end">
+      <%= button_to "Delete", registration_path(resource_name), data: { confirm: "Are you sure?" },
+          method: :delete, class: "button-primary bg-gray hover-bg-red w4" %>
+    </div>
 
-    <h3>Cancel my account</h3>
-
-    <p>Unhappy?<br/><br/> <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
   </div>
 </div>

--- a/app/views/buyers/registrations/new.html.erb
+++ b/app/views/buyers/registrations/new.html.erb
@@ -5,37 +5,33 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="field">
-        <%= f.label :email %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+      <div class="mb3">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> alumni.sfai.edu required </p>
       </div>
 
-      <br /><br /><br />
-
-      <div class="field">
-        <%= f.label :password %>
-        <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em>
-        <% end %><br /><br />
-        <%= f.password_field :password, class: "field", autocomplete: "new-password" %>
+      <div class="mb3">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password" %>
+          <% if @minimum_password_length %>
+            <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
+          <% end %>
       </div>
 
-      <br /><br /><br />
 
-      <div class="field">
-        <%= f.label :password_confirmation %><br /><br />
-        <%= f.password_field :password_confirmation, class: "field", autocomplete: "new-password" %>
+      <div class="mb3">
+        <%= f.label :password_confirmation, class: "mb1" %>
+        <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password" %>
       </div>
 
-      <br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Sign up", class: "button" %>
+      <div class="flex justify-between">
+        <div class="flex flex-column justify-around">
+        <%= render "buyers/shared/links" %>
+        </div>
+        <%= f.submit "Sign up", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
 
-    <br /><br />
-
-    <%= render "buyers/shared/links" %>
   </div>
 </div>

--- a/app/views/buyers/registrations/new.html.erb
+++ b/app/views/buyers/registrations/new.html.erb
@@ -8,7 +8,7 @@
       <div class="mb3">
         <%= f.label :email %>
         <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
-        <p class="texthelp"> alumni.sfai.edu required </p>
+        <p class="texthelp"> alumni.sfai.edu email required </p>
       </div>
 
       <div class="mb3">

--- a/app/views/buyers/registrations/new.html.erb
+++ b/app/views/buyers/registrations/new.html.erb
@@ -26,9 +26,7 @@
       </div>
 
       <div class="flex justify-between">
-        <div class="flex flex-column justify-around">
         <%= render "buyers/shared/links" %>
-        </div>
         <%= f.submit "Sign up", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>

--- a/app/views/buyers/registrations/new.html.erb
+++ b/app/views/buyers/registrations/new.html.erb
@@ -20,7 +20,7 @@
       </div>
 
 
-      <div class="mb3">
+      <div class="mb4">
         <%= f.label :password_confirmation, class: "mb1" %>
         <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password" %>
       </div>

--- a/app/views/buyers/sessions/new.html.erb
+++ b/app/views/buyers/sessions/new.html.erb
@@ -20,7 +20,7 @@
       </div>
 
       <% if devise_mapping.rememberable? -%>
-        <div class="mb3">
+        <div class="mb4">
           <%= f.check_box :remember_me %>
           <%= f.label :remember_me %>
         </div>

--- a/app/views/buyers/sessions/new.html.erb
+++ b/app/views/buyers/sessions/new.html.erb
@@ -7,35 +7,32 @@
         <% flash.each do |key, value| %>
            <div class="flash <%= key %>"><%= value %></div>
         <% end %>
-        <br />
-      <div class="field">
-        <%= f.label :email %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email", value: "bill@gates.com" %>
+
+      <div class="mb3">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> alumni.sfai.edu required </p>
       </div>
 
-      <br /><br /><br />
-
-      <div class="field">
-        <%= f.label :password %><br /><br />
-        <%= f.password_field :password, class: "field", autocomplete: "current-password", value: "password1" %>
+      <div class="mb3">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: "textinput w-100", autocomplete: "current-password" %>
       </div>
-
-      <br /><br /><br />
 
       <% if devise_mapping.rememberable? -%>
-        <div class="field">
+        <div class="mb3">
           <%= f.check_box :remember_me %>
           <%= f.label :remember_me %>
         </div>
       <% end -%>
 
-      <div class="actions">
-        <%= f.submit "Log in", class: "button" %>
-      </div>
+      <div class="flex justify-between">
+        <div class="flex flex-column justify-around">
+          <%= render "buyers/shared/links" %>
+        </div>
+      <%= f.submit "Log in", class: "button-primary bg-mustard w4" %>
+    </div>
     <% end %>
 
-    <br /><br />
-
-    <%= render "buyers/shared/links" %>
   </div>
 </div>

--- a/app/views/buyers/sessions/new.html.erb
+++ b/app/views/buyers/sessions/new.html.erb
@@ -11,7 +11,7 @@
       <div class="mb3">
         <%= f.label :email %>
         <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
-        <p class="texthelp"> alumni.sfai.edu required </p>
+        <p class="texthelp"> alumni.sfai.edu email required </p>
       </div>
 
       <div class="mb3">

--- a/app/views/buyers/sessions/new.html.erb
+++ b/app/views/buyers/sessions/new.html.erb
@@ -27,11 +27,9 @@
       <% end -%>
 
       <div class="flex justify-between">
-        <div class="flex flex-column justify-around">
-          <%= render "buyers/shared/links" %>
-        </div>
-      <%= f.submit "Log in", class: "button-primary bg-mustard w4" %>
-    </div>
+        <%= render "buyers/shared/links" %>
+        <%= f.submit "Log in", class: "button-primary bg-mustard w4" %>
+      </div>
     <% end %>
 
   </div>

--- a/app/views/buyers/shared/_links.html.erb
+++ b/app/views/buyers/shared/_links.html.erb
@@ -1,3 +1,4 @@
+<div class="flex flex-column justify-around">
 <%- if controller_name != 'sessions' %>
   <%= link_to "Log in »", new_session_path(resource_name) %>
 <% end -%>
@@ -23,3 +24,4 @@
     <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %>
   <% end -%>
 <% end -%>
+</div>

--- a/app/views/buyers/shared/_links.html.erb
+++ b/app/views/buyers/shared/_links.html.erb
@@ -1,9 +1,9 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %>
+  <%= link_to "Log in »", new_session_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %>
+  <%= link_to "Sign up »", new_registration_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
@@ -11,7 +11,7 @@
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %>
+  <%= link_to "Didn't receive email?", new_confirmation_path(resource_name) %>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/app/views/buyers/shared/_links.html.erb
+++ b/app/views/buyers/shared/_links.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Log in »", new_session_path(resource_name) %>
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+<%- if devise_mapping.registerable? && controller_name == 'sessions' %>
   <%= link_to "Sign up »", new_registration_path(resource_name) %>
 <% end -%>
 
@@ -10,7 +10,7 @@
   <%= link_to "Forgot your password?", new_password_path(resource_name) %>
 <% end -%>
 
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+<%- if devise_mapping.confirmable? && controller_name == 'registrations' %>
   <%= link_to "Didn't receive email?", new_confirmation_path(resource_name) %>
 <% end -%>
 

--- a/app/views/buyers/unlocks/new.html.erb
+++ b/app/views/buyers/unlocks/new.html.erb
@@ -5,20 +5,16 @@
     <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
       <%= devise_error_messages! %>
 
-      <div class="field">
-        <%= f.label :email %><br /><br />
-        <%= f.email_field :email, class: "field", autofocus: true, autocomplete: "email" %>
+      <div class="mb4">
+        <%= f.label :email %>
+        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email" %>
+        <p class="texthelp"> alumni.sfai.edu email required </p>
       </div>
 
-      <br /><br /><br />
-
-      <div class="actions">
-        <%= f.submit "Resend unlock instructions", class: "button" %>
+      <div class="flex justify-between">
+        <%= render "buyers/shared/links" %>
+        <%= f.submit "Submit", class: "button-primary bg-mustard w4" %>
       </div>
     <% end %>
-
-    <br /><br />
-
-    <%= render "buyers/shared/links" %>
   </div>
 </div>


### PR DESCRIPTION
## Restyle account flow

* Replaced most custom classes with Tachyons
* Styled links & checkbox to be theme color
* Added help text

Files touched: [sign up, login, forgot password, resend confirmation emails] x [artists, patrons]
### Related PRs
#60 

### Screenshots
![screen recording 2019-02-27 at 12 06 am](https://user-images.githubusercontent.com/13279205/53475030-b7987880-3a23-11e9-87da-e435a80a549b.gif)
