### PR TITLE
Signup back button, errors

### DIFF
--- a/app/assets/javascripts/signin.js
+++ b/app/assets/javascripts/signin.js
@@ -18,6 +18,45 @@ enableSubmit = (el) => {
 	}
 }
 
+validateEmail = (email, showError, isArtist) => {
+	const atIndex = email.val().indexOf("@");
+	if (!email.val() ||
+			atIndex == -1 ||
+			email.val().slice(atIndex + 1, email.val().length) != (isArtist ? "artists.sfai.edu" : "alumni.sfai.edu")) {
+		
+		if (showError) { email.next(".texthelp").addClass("error"); }
+		return false;
+	} else {
+		email.next(".texthelp").removeClass("error");
+		return true;
+	}
+}
+
+validatePassword = (password, showError) => {
+	if (!password.val() || password.val().length < 6) {
+		if (showError) { password.next(".texthelp").addClass("error"); }
+		return false;
+	} else {
+		password.next(".texthelp").removeClass("error");
+		return true;
+	}
+}
+
+validateConfirmation = (password, confirmation, showError) => {
+	console.log('hnng');
+	if (password.val() != confirmation.val()) {
+		if (showError &&
+			confirmation.next(".texthelp").length == 0) { 
+			confirmation.after('<p class="texthelp error">Passwords must match</p>')
+		}
+		return false;
+	} else {
+		confirmation.next(".texthelp").remove();
+		return true;
+	}
+
+}
+
 validateForm = (showEmailError, showPasswordError, showConfirmationError) => {
 	let valid = true;
 	const isArtist = $("form").hasClass("new_artist");
@@ -32,42 +71,10 @@ validateForm = (showEmailError, showPasswordError, showConfirmationError) => {
 		passwordConfirmation = $('input[name="buyer[password_confirmation]"]');
 	}
 
-	/* Validate email domain is correct */
-	const atIndex = email.val().indexOf("@");
-	if (!email.val() ||
-			atIndex == -1 ||
-			email.val().slice(atIndex + 1, email.val().length) != (isArtist ? "artists.sfai.edu" : "alumni.sfai.edu")) {
-		
-		if (showEmailError) { email.next(".texthelp").addClass("error"); }
-		valid = false;
-	} else {
-		email.next(".texthelp").removeClass("error");
-	}
-
-	/* Validate password is minimum length */
-	if (!password.val() || password.val().length < 6) {
-		if (showPasswordError) { password.next(".texthelp").addClass("error"); }
-		valid = false;
-	} else {
-		password.next(".texthelp").removeClass("error");
-	}
-
-	/* Validate password confirmation is minimum length */
-	if (!passwordConfirmation.val() ||
-		passwordConfirmation.val().length < 6) {
-		valid = false;
-	}
-
-	/* Validate password and password confirmation match up */
-	if (password.val() != passwordConfirmation.val()) {
-		if (showConfirmationError &&
-			passwordConfirmation.next(".texthelp").length == 0) { 
-			passwordConfirmation.after('<p class="texthelp error">Passwords must match</p>')
-		}
-		valid = false;
-	} else {
-		passwordConfirmation.next(".texthelp").remove();
-	}
+	valid = validateEmail(email, showEmailError, isArtist) &&
+			validatePassword(password, showPasswordError) &&
+			validateConfirmation(
+				password, passwordConfirmation, showConfirmationError);
 
 	/* Enable button if no errors */	
 	if (valid) {

--- a/app/assets/javascripts/signin.js
+++ b/app/assets/javascripts/signin.js
@@ -43,7 +43,6 @@ validatePassword = (password, showError) => {
 }
 
 validateConfirmation = (password, confirmation, showError) => {
-	console.log('hnng');
 	if (password.val() != confirmation.val()) {
 		if (showError &&
 			confirmation.next(".texthelp").length == 0) { 

--- a/app/assets/javascripts/signin.js
+++ b/app/assets/javascripts/signin.js
@@ -5,6 +5,11 @@ nextPage = () => {
 	}
 }
 
+prevPage = () => {
+	$(".signup.part2").hide();
+	$(".signup.part1").show();
+}
+
 enableNextPage = () => {
 	if (validateForm()) {
 		$('button').removeAttr('disabled');

--- a/app/assets/javascripts/signin.js
+++ b/app/assets/javascripts/signin.js
@@ -10,14 +10,6 @@ prevPage = () => {
 	$(".signup.part1").show();
 }
 
-enableNextPage = () => {
-	if (validateForm()) {
-		$('button').removeAttr('disabled');
-	} else {
-		$('button').attr('disabled', 'disabled');
-	}
-}
-
 enableSubmit = (el) => {
 	if ($(el).is(":checked")) {
 		$('input[type="submit"]').removeAttr('disabled');
@@ -26,10 +18,10 @@ enableSubmit = (el) => {
 	}
 }
 
-validateForm = () => {
+validateForm = (showEmailError, showPasswordError, showConfirmationError) => {
+	let valid = true;
 	const isArtist = $("form").hasClass("new_artist");
 	let email, password, passwordConfirmation;
-
 	if (isArtist) {
 		email = $('input[name="artist[email]"]');
 		password = $('input[name="artist[password]"]');
@@ -40,25 +32,47 @@ validateForm = () => {
 		passwordConfirmation = $('input[name="buyer[password_confirmation]"]');
 	}
 
+	/* Validate email domain is correct */
 	const atIndex = email.val().indexOf("@");
 	if (!email.val() ||
 			atIndex == -1 ||
 			email.val().slice(atIndex + 1, email.val().length) != (isArtist ? "artists.sfai.edu" : "alumni.sfai.edu")) {
-		return false;
+		
+		if (showEmailError) { email.next(".texthelp").addClass("error"); }
+		valid = false;
+	} else {
+		email.next(".texthelp").removeClass("error");
 	}
 
+	/* Validate password is minimum length */
 	if (!password.val() || password.val().length < 6) {
-		return false;
+		if (showPasswordError) { password.next(".texthelp").addClass("error"); }
+		valid = false;
+	} else {
+		password.next(".texthelp").removeClass("error");
 	}
 
+	/* Validate password confirmation is minimum length */
 	if (!passwordConfirmation.val() ||
 		passwordConfirmation.val().length < 6) {
-		return false;
+		valid = false;
 	}
 
+	/* Validate password and password confirmation match up */
 	if (password.val() != passwordConfirmation.val()) {
-		return false;
+		if (showConfirmationError &&
+			passwordConfirmation.next(".texthelp").length == 0) { 
+			passwordConfirmation.after('<p class="texthelp error">Passwords must match</p>')
+		}
+		valid = false;
+	} else {
+		passwordConfirmation.next(".texthelp").remove();
 	}
 
-  return true; 
+	/* Enable button if no errors */	
+	if (valid) {
+		$('button').removeAttr('disabled');
+	} else {
+		$('button').attr('disabled', 'disabled');
+	}
 }

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -106,6 +106,10 @@ input[type="checkbox"] {
   color: $gray;
 }
 
+.texthelp.error {
+  color: $light-red;
+}
+
 .input-dropdown {
   @extend .row-input;
   height: 2rem;

--- a/app/assets/stylesheets/pages/Login.scss
+++ b/app/assets/stylesheets/pages/Login.scss
@@ -29,10 +29,6 @@
   input {
     border-style: none;
   }
-
-  input.invalid {
-    background-color: $red;
-  }
   
   input[type="checkbox"] {
     &:after {

--- a/app/assets/stylesheets/pages/Login.scss
+++ b/app/assets/stylesheets/pages/Login.scss
@@ -19,6 +19,8 @@
   }
   a {
     @extend .mustard;
+    cursor: pointer;
+    
     &:hover {
 			text-decoration: underline;
 		}

--- a/app/views/artists/registrations/new.html.erb
+++ b/app/views/artists/registrations/new.html.erb
@@ -7,13 +7,13 @@
 
     <div class="mb3">
       <%= f.label :email %>
-      <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email", oninput: "enableNextPage()" %>
+      <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email", oninput: "validateForm(true, false, false)" %>
       <p class="texthelp"> artists.sfai.edu email required </p>
     </div>
 
     <div class="mb3">
         <%= f.label :password %>
-        <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password", oninput: "enableNextPage()" %>
+        <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm(false, true, false)" %>
         <% if @minimum_password_length %>
           <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
         <% end %>
@@ -21,7 +21,7 @@
 
     <div class="mb4">
       <%= f.label :password_confirmation, class: "mb1" %>
-      <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password", oninput: "enableNextPage()" %>
+      <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm(false, false, true)" %>
     </div>
 
     <div class="flex justify-between">

--- a/app/views/artists/registrations/new.html.erb
+++ b/app/views/artists/registrations/new.html.erb
@@ -31,7 +31,7 @@
   </div>
 
   <div class="container signup part2 dn">
-
+    <a id="back" onclick="prevPage()" class="mb3">« Back</a>
     <%= render "artists/shared/terms" %>
 
     <div class="flex justify-between items-baseline">

--- a/app/views/artists/registrations/new.html.erb
+++ b/app/views/artists/registrations/new.html.erb
@@ -7,13 +7,13 @@
 
     <div class="mb3">
       <%= f.label :email %>
-      <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email", oninput: "validateForm(true, false, false)" %>
+      <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email", oninput: "validateForm()", onblur: "validateForm(true, false, false)" %>
       <p class="texthelp"> artists.sfai.edu email required </p>
     </div>
 
     <div class="mb3">
         <%= f.label :password %>
-        <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm(false, true, false)" %>
+        <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm()", onblur: "validateForm(false, true, false)" %>
         <% if @minimum_password_length %>
           <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
         <% end %>
@@ -21,7 +21,7 @@
 
     <div class="mb4">
       <%= f.label :password_confirmation, class: "mb1" %>
-      <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm(false, false, true)" %>
+      <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm()", onblur: "validateForm(false, false, true)" %>
     </div>
 
     <div class="flex justify-between">

--- a/app/views/buyers/registrations/new.html.erb
+++ b/app/views/buyers/registrations/new.html.erb
@@ -1,28 +1,27 @@
 <div class="loginPage">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+
   <div class="container signup part1">
     <h1>Sign up</h1>
+    <%= devise_error_messages! %>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= devise_error_messages! %>
+    <div class="mb3">
+      <%= f.label :email %>
+      <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email", oninput: "validateForm(true, false, false)" %>
+      <p class="texthelp"> alumni.sfai.edu email required </p>
+    </div>
 
-      <div class="mb3">
-        <%= f.label :email %>
-        <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email", oninput: "enableNextPage()" %>
-        <p class="texthelp"> alumni.sfai.edu email required </p>
-      </div>
-
-      <div class="mb3">
-          <%= f.label :password %>
-          <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password", oninput: "enableNextPage()" %>
-          <% if @minimum_password_length %>
-            <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
-          <% end %>
-      </div>
-
+    <div class="mb3">
+        <%= f.label :password %>
+        <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm(false, true, false)" %>
+        <% if @minimum_password_length %>
+          <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
+        <% end %>
+    </div>
 
     <div class="mb4">
       <%= f.label :password_confirmation, class: "mb1", oninput: "resetStyle(this)" %>
-      <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password", oninput: "enableNextPage()" %>
+      <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm(false, false, true)" %>
     </div>
 
     <div class="flex justify-between">

--- a/app/views/buyers/registrations/new.html.erb
+++ b/app/views/buyers/registrations/new.html.erb
@@ -32,7 +32,7 @@
   </div>
 
   <div class="container signup part2 dn">
-
+    <a id="back" onclick="prevPage()" class="mb3">« Back</a>
     <%= render "artists/shared/terms" %>
 
     <div class="flex justify-between items-baseline">

--- a/app/views/buyers/registrations/new.html.erb
+++ b/app/views/buyers/registrations/new.html.erb
@@ -7,13 +7,13 @@
 
     <div class="mb3">
       <%= f.label :email %>
-      <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email", oninput: "validateForm(true, false, false)" %>
+      <%= f.email_field :email, class: "textinput w-100", autofocus: true, autocomplete: "email", oninput: "validateForm()", onblur: "validateForm(true, false, false)" %>
       <p class="texthelp"> alumni.sfai.edu email required </p>
     </div>
 
     <div class="mb3">
         <%= f.label :password %>
-        <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm(false, true, false)" %>
+        <%= f.password_field :password, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm()", onblur: "validateForm(false, true, false)" %>
         <% if @minimum_password_length %>
           <p class="texthelp"> <%= @minimum_password_length %> characters minimum </p>
         <% end %>
@@ -21,7 +21,7 @@
 
     <div class="mb4">
       <%= f.label :password_confirmation, class: "mb1", oninput: "resetStyle(this)" %>
-      <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm(false, false, true)" %>
+      <%= f.password_field :password_confirmation, class: "textinput w-100", autocomplete: "new-password", oninput: "validateForm()", onblur: "validateForm(false, false, true)" %>
     </div>
 
     <div class="flex justify-between">


### PR DESCRIPTION
## Signup back button, errors
For artist + buyer sign up:
* Include back button on second page of form (terms and conditions)
* Display form validation error (incorrect email domain, password length, password confirmation)

### Related PRs
https://github.com/calblueprint/SFAI/pull/65

### Migrations
None

### Tests Performed, Edge Cases
None

### Screenshots
_the ending loading cut off but after signup it should redirect to the landing page_
![error](https://user-images.githubusercontent.com/23442055/53680305-7e177580-3c8e-11e9-8697-5e58057d29ec.gif)

CC: @by-co
