### PR TITLE
Wrapped checkboxes in gallery and artist tabs with labels

### DIFF
--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -26,10 +26,6 @@ input[type="checkbox"] {
   }
 }
 
-.display-inline-block {
-  display: inline-block;
-}
-
 .checkbox-item {
   display: flex;
   align-items: center;

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -26,6 +26,10 @@ input[type="checkbox"] {
   }
 }
 
+.display-inline-block {
+  display: inline-block;
+}
+
 .checkbox-item {
   display: flex;
   align-items: center;

--- a/app/assets/stylesheets/partials/_fonts.scss
+++ b/app/assets/stylesheets/partials/_fonts.scss
@@ -12,10 +12,6 @@ html, body {
 	font-size: 16px;
 }
 
-.capitalize {
-	text-transform: capitalize;
-}
-
 h1 {
 	font-weight: bold;
 	font-size: 40px;

--- a/app/javascript/components/works/Filters.jsx
+++ b/app/javascript/components/works/Filters.jsx
@@ -69,13 +69,16 @@ class Filters extends PureComponent {
                 <div className="checkbox-container">
                   {Object.keys(filters[type]).map(item => (
                     <div className="mb2 checkbox-item" key={item}>
-                      <input
-                        onClick={() => this.toggleCheckbox(type, item)}
-                        type="checkbox"
-                        className="checkbox"
-                        value={item}
-                      />
-                      <p className="capitalize">{convertSnakeCase(item)}</p>
+                      <label for={`checkbox-${item}`}>
+                        <input
+                          onClick={() => this.toggleCheckbox(type, item)}
+                          type="checkbox"
+                          className="checkbox"
+                          value={item}
+                          id={`checkbox-${item}`}
+                        />
+                        <p className="capitalize display-inline-block">{convertSnakeCase(item)}</p>
+                      </label>
                     </div>
                   ))}
                 </div>

--- a/app/javascript/components/works/Filters.jsx
+++ b/app/javascript/components/works/Filters.jsx
@@ -77,7 +77,7 @@ class Filters extends PureComponent {
                           value={item}
                           id={`checkbox-${item}`}
                         />
-                        <p className="capitalize display-inline-block">{convertSnakeCase(item)}</p>
+                        <p className="ttc dib">{convertSnakeCase(item)}</p>
                       </label>
                     </div>
                   ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6679,7 +6679,7 @@ trim-right@^1.0.1:
   dependencies:
     glob "^7.1.2"
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==


### PR DESCRIPTION
## Replaced Checkboxes with Labels
Originally, users had to click on checkboxes to check values in the gallery and artist tabs. Using labels, they can click on the text to check these boxes.

### Related PRs
None.

### Migrations
None.

### Tests Performed, Edge Cases
None.

### Screenshots
![sfai_label_checkboxes](https://user-images.githubusercontent.com/21699109/54098024-f9081c80-436f-11e9-8abb-0716deebe519.gif)

CC: @by-co
