### PR TITLE
Limiting patron to a single request for a request type for any work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'rb-readline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    rb-readline (0.5.5)
     react-rails (2.4.7)
       babel-transpiler (>= 0.7.0)
       connection_pool
@@ -292,6 +293,7 @@ DEPENDENCIES
   pg
   puma (~> 3.11)
   rails (~> 5.2.1)
+  rb-readline
   react-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/javascripts/helpers/APIRoutes.js
+++ b/app/assets/javascripts/helpers/APIRoutes.js
@@ -39,7 +39,8 @@ class ApiRoutes {
       show: (id) => `/api/requests/${id}`,
       update: (id) => `/api/requests/${id}`,
       create: `/api/requests`,
-      types: '/requests/types'
+      types: '/requests/types',
+      request_exist: (search_params) => `/api/requests/request_exist/${search_params}`
     }
   }
 

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -29,6 +29,12 @@ class Api::RequestsController < ApplicationController
     render json: {status: 200, message: 'Request successfully updated!'}
   end
 
+  def request_exist
+    parsed_query = CGI.parse(params[:search_params])
+    exist = Request.where(parsed_query)
+    render json: exist
+  end
+
   def request_params
     params.require(:request).permit(:open,
                                     :message,

--- a/app/javascript/components/requests/RequestForm.jsx
+++ b/app/javascript/components/requests/RequestForm.jsx
@@ -11,12 +11,13 @@ class RequestForm extends React.Component {
       available: this.props.work_status === "active" ? true : false,
       request: {
         message: "",
-        types: 0
+        types: 'sale'
       },
       request_types: {},
       errors: {
         message: "",
-        login: ""
+        login: "",
+        exist: ""
       },
       updatingRequest: false,
       componentDidMount: false
@@ -73,7 +74,8 @@ class RequestForm extends React.Component {
   checkErrors() {
     let errors = {
       message: "",
-      login: ""
+      login: "",
+      exist: ""
     }
 
     if (!this.state.request.message) {
@@ -82,9 +84,34 @@ class RequestForm extends React.Component {
     if (!this.props.buyer) {
       errors["login"] = "You must be logged in to request a work."
     }
+    let y = this.checkExist()
+    console.log(y)
+    if (y) {
+      errors["exist"] = "You have already made a request under this request type."
+    }
+    console.log(errors)
 
     return errors;
   }
+
+  checkExist() {
+    let stringifiedSearchParams = [`buyer_id=${this.props.buyer.id}`, `artist_id=${this.props.artist_id}`,
+      `work_id=${this.props.work_id}`, `types=${this.state.request.types}`].join('&')
+      console.log(stringifiedSearchParams)
+    let request_route = APIRoutes.requests.request_exist(stringifiedSearchParams)
+    console.log(request_route)
+    let result = false
+    let promise = Requester.get(request_route).then(
+          response => {
+            if (response.length == 0) {
+            } else {
+              result = true
+            }
+          },
+          response => { console.error(response); }
+      );
+      return result
+    }
 
   render() {
     if (!this.state.componentDidMount) {

--- a/app/javascript/components/requests/RequestForm.jsx
+++ b/app/javascript/components/requests/RequestForm.jsx
@@ -26,7 +26,7 @@ class RequestForm extends React.Component {
   }
 
   componentDidMount = () => {
-    this.checkExist()
+    this.checkExist('sale')
     const requests_types_route = APIRoutes.requests.types;
     Requester.get(requests_types_route).then((response) => {
       this.setState({ request_types: response, componentDidMount: true });
@@ -36,16 +36,14 @@ class RequestForm extends React.Component {
   }
 
   handleChange = event => {
-    if (event.target.name == 'types') {
-      this.checkExist()
-      console.log("Entered.")
-    }
     const request = this.state.request;
     const name = event.target.name;
     const value = event.target.value;
     request[name] = value;
     this.setState({ request: request });
-    console.log(this.state.exist)
+    if (event.target.name == 'types') {
+      this.checkExist(value)
+    }
   }
 
   handleSubmit = () => {
@@ -97,9 +95,9 @@ class RequestForm extends React.Component {
     return errors;
   }
 
-  checkExist() {
+  checkExist = (request_type) => {
     let stringifiedSearchParams = [`buyer_id=${this.props.buyer.id}`, `artist_id=${this.props.artist_id}`,
-      `work_id=${this.props.work_id}`, `types=${this.state.request.types}`].join('&')
+      `work_id=${this.props.work_id}`, `types=${request_type}`].join('&')
     let request_route = APIRoutes.requests.request_exist(stringifiedSearchParams)
     Requester.get(request_route).then(
         response => {

--- a/app/javascript/components/requests/RequestForm.jsx
+++ b/app/javascript/components/requests/RequestForm.jsx
@@ -36,7 +36,10 @@ class RequestForm extends React.Component {
   }
 
   handleChange = event => {
-    this.checkExist()
+    if (event.target.name == 'types') {
+      this.checkExist()
+      console.log("Entered.")
+    }
     const request = this.state.request;
     const name = event.target.name;
     const value = event.target.value;
@@ -89,9 +92,7 @@ class RequestForm extends React.Component {
       errors["login"] = "You must be logged in to request a work."
     }
     if (this.state.exist) {
-      console.log("HERE")
       errors["exist"] = "You have already made a request under this request type."
-      console.log(errors)
     }
     return errors;
   }
@@ -99,9 +100,7 @@ class RequestForm extends React.Component {
   checkExist() {
     let stringifiedSearchParams = [`buyer_id=${this.props.buyer.id}`, `artist_id=${this.props.artist_id}`,
       `work_id=${this.props.work_id}`, `types=${this.state.request.types}`].join('&')
-      // console.log(stringifiedSearchParams)
     let request_route = APIRoutes.requests.request_exist(stringifiedSearchParams)
-    // console.log(request_route)
     Requester.get(request_route).then(
         response => {
           if (response.length != 0) {

--- a/app/javascript/components/requests/RequestForm.jsx
+++ b/app/javascript/components/requests/RequestForm.jsx
@@ -96,8 +96,14 @@ class RequestForm extends React.Component {
   }
 
   checkExist = (request_type) => {
-    let stringifiedSearchParams = [`buyer_id=${this.props.buyer.id}`, `artist_id=${this.props.artist_id}`,
-      `work_id=${this.props.work_id}`, `types=${request_type}`].join('&')
+    const { buyer, artist_id, work_id } = this.props;
+    let stringifiedSearchParams = [
+      `buyer_id=${buyer.id}`,
+      `artist_id=${artist_id}`,
+      `work_id=${work_id}`,
+      `types=${request_type}`
+    ].join("&");
+    
     let request_route = APIRoutes.requests.request_exist(stringifiedSearchParams)
     Requester.get(request_route).then(
         response => {

--- a/app/javascript/components/requests/RequestForm.jsx
+++ b/app/javascript/components/requests/RequestForm.jsx
@@ -19,12 +19,14 @@ class RequestForm extends React.Component {
         login: "",
         exist: ""
       },
+      exist: false,
       updatingRequest: false,
       componentDidMount: false
     }
   }
 
   componentDidMount = () => {
+    this.checkExist()
     const requests_types_route = APIRoutes.requests.types;
     Requester.get(requests_types_route).then((response) => {
       this.setState({ request_types: response, componentDidMount: true });
@@ -34,11 +36,13 @@ class RequestForm extends React.Component {
   }
 
   handleChange = event => {
+    this.checkExist()
     const request = this.state.request;
     const name = event.target.name;
     const value = event.target.value;
     request[name] = value;
     this.setState({ request: request });
+    console.log(this.state.exist)
   }
 
   handleSubmit = () => {
@@ -84,33 +88,30 @@ class RequestForm extends React.Component {
     if (!this.props.buyer) {
       errors["login"] = "You must be logged in to request a work."
     }
-    let y = this.checkExist()
-    console.log(y)
-    if (y) {
+    if (this.state.exist) {
+      console.log("HERE")
       errors["exist"] = "You have already made a request under this request type."
+      console.log(errors)
     }
-    console.log(errors)
-
     return errors;
   }
 
   checkExist() {
     let stringifiedSearchParams = [`buyer_id=${this.props.buyer.id}`, `artist_id=${this.props.artist_id}`,
       `work_id=${this.props.work_id}`, `types=${this.state.request.types}`].join('&')
-      console.log(stringifiedSearchParams)
+      // console.log(stringifiedSearchParams)
     let request_route = APIRoutes.requests.request_exist(stringifiedSearchParams)
-    console.log(request_route)
-    let result = false
-    let promise = Requester.get(request_route).then(
-          response => {
-            if (response.length == 0) {
-            } else {
-              result = true
-            }
-          },
+    // console.log(request_route)
+    Requester.get(request_route).then(
+        response => {
+          if (response.length != 0) {
+            this.setState({ exist: true })
+          } else {
+            this.setState({ exist: false })
+          }
+        },
           response => { console.error(response); }
       );
-      return result
     }
 
   render() {
@@ -165,6 +166,7 @@ class RequestForm extends React.Component {
           />
           <FormError error={this.state.errors["message"]} />
           <FormError error={this.state.errors["login"]} />
+          <FormError error={this.state.errors["exist"]} />
           <button onClick={this.handleSubmit} className="button-primary bg-magenta w4 mt2">
             Submit
           </button>

--- a/app/javascript/components/works/Works.jsx
+++ b/app/javascript/components/works/Works.jsx
@@ -39,7 +39,6 @@ class Works extends React.Component {
     const works_route = searchParams.length
       ? APIRoutes.works.filtered_works(searchParams)
       : APIRoutes.works.index;
-    console.log(works_route)
 
     Requester.get(
       works_route).then(

--- a/app/javascript/components/works/Works.jsx
+++ b/app/javascript/components/works/Works.jsx
@@ -39,6 +39,7 @@ class Works extends React.Component {
     const works_route = searchParams.length
       ? APIRoutes.works.filtered_works(searchParams)
       : APIRoutes.works.index;
+    console.log(works_route)
 
     Requester.get(
       works_route).then(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,5 +54,6 @@ Rails.application.routes.draw do
     get 'receipts/artist/:id' => 'artists#receipts'
     get 'works/thumbnail/:id' => 'works#thumbnail'
     get 'artists/commissions/:id' => 'artists#commissions'
+    get 'requests/request_exist/:search_params' => 'requests#request_exist'
   end
 end


### PR DESCRIPTION
## Feature Name: Limiting patrons to a single request for a request type for any work
Patrons used to be able to send in multiple requests of a particular request type, which is limited by this PR 

### Related PRs
None
### Migrations
None
### Tests Performed, Edge Cases
Tested on a few artists and multiple requests.

CC: @by-co
![SFAItommylimit_feature](https://user-images.githubusercontent.com/35573990/54387428-9e650e00-4658-11e9-8a51-cd244d24dc2d.gif)
