### PR TITLE
redirect to artist page after creating new work

### DIFF
--- a/app/javascript/components/works/WorkForm.jsx
+++ b/app/javascript/components/works/WorkForm.jsx
@@ -143,7 +143,11 @@ class WorkForm extends React.Component {
           "X_CSRF-Token": document.getElementsByName("csrf-token")[0].content
         }
       }).then((data) => {
-        window.location = `/works/` + this.state.work.id;
+        if (typeof this.state.work.id == 'number') {
+          window.location = `/works/` + this.state.work.id;
+        } else {
+          window.location = `/artists/` + this.props.artist.id;
+        }
       }).catch((data) => {
         console.error(data);
       });


### PR DESCRIPTION
## Fix edge case on CreateWork
- redirect to `/artist` page after creating new work
- otherwise work.id is not accessible / not defined

### Related PRs
#81 