### PR TITLE
Fixed bug: props.buyer = null breaks checkExist function in RequestForm.jsx

### DIFF
--- a/app/javascript/components/requests/RequestForm.jsx
+++ b/app/javascript/components/requests/RequestForm.jsx
@@ -97,24 +97,28 @@ class RequestForm extends React.Component {
 
   checkExist = (request_type) => {
     const { buyer, artist_id, work_id } = this.props;
-    let stringifiedSearchParams = [
-      `buyer_id=${buyer.id}`,
-      `artist_id=${artist_id}`,
-      `work_id=${work_id}`,
-      `types=${request_type}`
-    ].join("&");
-    
-    let request_route = APIRoutes.requests.request_exist(stringifiedSearchParams)
-    Requester.get(request_route).then(
-        response => {
-          if (response.length != 0) {
-            this.setState({ exist: true })
-          } else {
-            this.setState({ exist: false })
-          }
-        },
-          response => { console.error(response); }
-      );
+    if (buyer == null) {
+      return
+    } else {
+      let stringifiedSearchParams = [
+        `buyer_id=${buyer.id}`,
+        `artist_id=${artist_id}`,
+        `work_id=${work_id}`,
+        `types=${request_type}`
+      ].join("&");
+
+      let request_route = APIRoutes.requests.request_exist(stringifiedSearchParams)
+      Requester.get(request_route).then(
+          response => {
+            if (response.length != 0) {
+              this.setState({ exist: true })
+            } else {
+              this.setState({ exist: false })
+            }
+          },
+            response => { console.error(response); }
+        );
+      }
     }
 
   render() {


### PR DESCRIPTION
## Feature Name: Fixed bug – props.buyer = null breaks checkExist function in RequestForm.jsx
Feature Description
Individual works page does not render if a buyer/patron is not signed in

### Related PRs
#83 

### Migrations
None
### Tests Performed, Edge Cases
Tested rendering when not logged in + when logged in as artist.

### Screenshots

CC: @by-co
