### PR TITLE
Bug Fix: Request confirmation sets work to unavailable

### DIFF
--- a/app/javascript/components/artists/ArtistProfile.jsx
+++ b/app/javascript/components/artists/ArtistProfile.jsx
@@ -178,10 +178,12 @@ class ArtistProfile extends React.Component {
                         <FontAwesomeIcon className="white" icon={faEdit} />
                         <h4 className="ml2 white">Edit</h4>
                       </Button>
+                      {(work.availability == 'active') &&
                       <Button className="ml2" type="hover-button" onClick={() => this.deleteWork(work.id)}>
                         <FontAwesomeIcon className="white" icon={faTrash} />
                         <h4 className="ml2 white">Delete</h4>
                       </Button>
+                      }
                     </div>
                   }
                 </WorkColumnPanel>

--- a/app/javascript/components/receipts/TransactionForm.jsx
+++ b/app/javascript/components/receipts/TransactionForm.jsx
@@ -64,6 +64,27 @@ class TransactionForm extends React.Component {
     return errors;
   }
 
+  updateWork = (work_id) => {
+    const trasactionType = this.state.receipt.transaction_type
+    let newAvailability = "sold"
+    if (trasactionType == 'rental') {
+      newAvailability = "rented"
+    }
+    let formData = new FormData();
+    formData.append(`work[availability]`, newAvailability);
+    fetch(APIRoutes.works.update(work_id), {
+      method: 'PUT',
+      body: formData,
+      credentials: 'same-origin',
+      headers: {
+        "X_CSRF-Token": document.getElementsByName("csrf-token")[0].content
+      }
+    }).then((data) => {
+      window.location.href = '/requests';
+      })
+    }
+
+
   handleSubmit = (event) => {
     const receipts_route = this.props.route;
     const method = this.props.method;
@@ -92,7 +113,7 @@ class TransactionForm extends React.Component {
       this.setState({ updatingTransaction: true });
       Requester.post(receipts_route, payload).then(
         response => {
-          window.location.href = '/requests';
+          this.updateWork(this.props.work.id)
         },
         error => {
           console.error(error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5233,7 +5233,7 @@ prop-types@^15.5.10, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.8:
+prop-types@^15.5.8, prop-types@^15.6.1:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5450,28 +5450,6 @@ react-paginate@^6.3.0:
   integrity sha512-lT/ne7hZzctGDli4QzUAou0JjfZgxKmtl9/r30B5UVonICZIy1u0SrAkdlEZ5ubgzrOykBeCmxkTWi5IyPg4AQ==
   dependencies:
     prop-types "^15.6.1"
-
-react-popper@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.2.tgz#0e72f338b7f15ab9f9ec884e36ae0dad78a3e301"
-  integrity sha512-vjZ94ki8sfCAg45MMi4uqnUUWdzbnYkb95sR2+HgiMaAPzQcy4DfDKYtYUOhhE+sdtkufWcUHLv09DmH2Js57w==
-  dependencies:
-    babel-runtime "6.x.x"
-    create-react-context "^0.2.1"
-    popper.js "^1.14.1"
-    prop-types "^15.6.1"
-    typed-styles "^0.0.5"
-    warning "^3.0.0"
-
-react-transition-group@^2.2.1:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
-  integrity sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==
-  dependencies:
-    dom-helpers "^3.3.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react@^16.5.2:
   version "16.6.0"


### PR DESCRIPTION
## Feature Name: Bug Fix: Request confirmation sets work to unavailable
- After confirming a request, will set a work to be unavailable / rented based on what the receipt type was
- User is unable to delete a work if it is unavailable / rented.

### Related PRs
None.
### Migrations
None.
### Tests Performed, Edge Cases
Performed tests on user
### Screenshots

CC: @by-co
