### PR TITLE
Disable Edit for Patron Receipts

### DIFF
--- a/app/javascript/components/requests/Receipt.jsx
+++ b/app/javascript/components/requests/Receipt.jsx
@@ -92,7 +92,6 @@ class Receipt extends React.Component {
                     <div className="z-1 absolute overlay-button">
                       {this.renderEditReceipt()}
                     </div>
-                    {this.getAttr(request)}
                   </div>
                 </div>
               ) : (
@@ -104,6 +103,9 @@ class Receipt extends React.Component {
                 </div>
               )
             }
+            <div className="attr-container pa3 mt2 relative">
+              {this.getAttr(request)}
+            </div>
           </div>
         </div>
       </div>

--- a/app/javascript/components/requests/Receipt.jsx
+++ b/app/javascript/components/requests/Receipt.jsx
@@ -81,10 +81,18 @@ class Receipt extends React.Component {
           <div className="request-container w-100">
             {
               this.props.artist ? (
-                <div className="request-action">
-                  <BuyerSnapshot buyer={this.state.request.buyer} />
-                  <div className = "w5">
-                    <p className = "closed-request-button pa3"> You completed this request on {closed_timestamps} </p>
+                <div>
+                  <div className="request-action">
+                    <BuyerSnapshot buyer={this.state.request.buyer} />
+                    <div className = "w5">
+                      <p className = "closed-request-button pa3"> You completed this request on {closed_timestamps} </p>
+                    </div>
+                  </div>
+                  <div className="attr-container pa3 mt2 relative">
+                    <div className="z-1 absolute overlay-button">
+                      {this.renderEditReceipt()}
+                    </div>
+                    {this.getAttr(request)}
                   </div>
                 </div>
               ) : (
@@ -96,12 +104,6 @@ class Receipt extends React.Component {
                 </div>
               )
             }
-            <div className="attr-container pa3 mt2 relative">
-              <div className="z-1 absolute overlay-button">
-                {this.renderEditReceipt()}
-              </div>
-              {this.getAttr(request)}
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Disable Edit for Patron Receipts
https://app.asana.com/0/860297512787618/1117335115640377/f

### Related PRs
#99 Implemented the backend auth for this

### Migrations
n/a

### Tests Performed, Edge Cases
you can't see it anymore on hover when you're logged in as a buyer 

### Screenshots
You can't see my mouse but it's hovering over and no Edit button is displaying : )
![image](https://user-images.githubusercontent.com/15094864/55604992-44230e80-5727-11e9-8db6-1f0940cdb113.png)

CC: @by-co
