### PR TITLE
Patron Notifications

### DIFF
--- a/app/controllers/api/works_controller.rb
+++ b/app/controllers/api/works_controller.rb
@@ -27,6 +27,11 @@ class Api::WorksController < ApplicationController
     featured_image = work_attr.delete("featured_image")
 
     @work = Work.find(params[:id])
+    if @work.availability != params[:work][:availability]
+      prev_status = @work.availability
+      curr_status = params[:work][:availability]
+    end
+
     saved = @work.update(work_attr)
     if saved
       if attachment_attr
@@ -39,6 +44,13 @@ class Api::WorksController < ApplicationController
       end
       self.assign_featured_image(featured_image, @work)
       flash[:success] = "Work updated successfully!"
+
+      if prev_status
+        requests = Request.where(work_id: @work.id)
+        requests.each do |req|
+          WorkMailer.with(buyer: req.buyer, work: @work, prev_status: prev_status, curr_status: curr_status).work_status_changed.deliver_later
+        end
+      end
     else
       flash[:danger] = "Work failed to create."
     end

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -19,4 +19,11 @@ class RequestMailer < ApplicationMailer
     @work = params[:work]
     mail(to: @buyer.email, subject: 'Request Completed')
   end
+
+  def request_deleted_email
+    @artist = params[:artist]
+    @buyer = params[:buyer]
+    @title = params[:title]
+    mail(to: @buyer.email, subject: 'Request Deleted')
+  end
 end

--- a/app/mailers/work_mailer.rb
+++ b/app/mailers/work_mailer.rb
@@ -4,6 +4,6 @@ class WorkMailer < ApplicationMailer
     @work = params[:work]
     @prev_status = params[:prev_status]
     @curr_status = params[:curr_status]
-    mail(to: @buyer.email, subject: 'New Request Opened')
+    mail(to: @buyer.email, subject: 'Requested Work Status Changed')
   end
 end

--- a/app/mailers/work_mailer.rb
+++ b/app/mailers/work_mailer.rb
@@ -1,0 +1,9 @@
+class WorkMailer < ApplicationMailer
+  def work_status_changed
+    @buyer = params[:buyer]
+    @work = params[:work]
+    @prev_status = params[:prev_status]
+    @curr_status = params[:curr_status]
+    mail(to: @buyer.email, subject: 'New Request Opened')
+  end
+end

--- a/app/views/request_mailer/request_deleted_email.html.erb
+++ b/app/views/request_mailer/request_deleted_email.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Request Deleted</h1>
+    <p>
+      Your request for <%= @title %> has been deleted because the
+      associated work has been deleted by the artist and is no longer
+      able to be requested. <br>
+    </p>
+    <p>Thanks for joining and have a great day!</p>
+  </body>
+</html>

--- a/app/views/work_mailer/work_status_changed.html.erb
+++ b/app/views/work_mailer/work_status_changed.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Requested Work Status Changed</h1>
+    <p>
+      The status of <%= @work.title %> has been updated from <strong><%= @prev_status %></strong>
+      to <strong><%= @curr_status %></strong> by the artist. <br>
+    </p>
+    <p>Thanks for joining and have a great day!</p>
+  </body>
+</html>

--- a/test/mailers/previews/work_mailer_preview.rb
+++ b/test/mailers/previews/work_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/work_mailer
+class WorkMailerPreview < ActionMailer::Preview
+
+end

--- a/test/mailers/work_mailer_test.rb
+++ b/test/mailers/work_mailer_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class WorkMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Patron Notifications
https://app.asana.com/0/860297512787618/1116222695913463/f

### Tests Performed, Edge Cases
Artist deletes work:
- 2 patron accounts, each opened a request on the same work
- Artist deletes work
- both patrons receive email that request has been deleted because work has been deleted

Artist changes availability of work:
- 2 patron accounts, each opened a request on the same work
- Artist uses Edit screen to change availability of work from Active -> Rented
- both patrons receive email that status of a work they have a request on has changed

### Screenshots
For deleting work
![image](https://user-images.githubusercontent.com/15094864/55606259-fad5bd80-572c-11e9-940a-70bc337628d2.png)

For changing availability
![image](https://user-images.githubusercontent.com/15094864/55606268-032df880-572d-11e9-8cf4-df6a7b508b65.png)

CC: @by-co
