### PR TITLE
Deleted Requests Bug

### DIFF
--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -44,6 +44,7 @@ class Api::RequestsController < ApplicationController
 
   def request_exist
     parsed_query = CGI.parse(params[:search_params])
+    parsed_query[:deleted] = [false, nil]
     exist = Request.where(parsed_query)
     render json: exist
   end


### PR DESCRIPTION
## Deleted Requests Bug
Fixed bug such that deleted requests aren't considered during form validation (checking if there is already an existing request of that type from the given buyer)

### Related PRs

### Migrations

### Tests Performed, Edge Cases

### Screenshots

CC: @by-co
