### PR TITLE
Thu/fix program filters

### DIFF
--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -35,8 +35,7 @@ class Api::ArtistsController < ApplicationController
       if (parsed_query.keys.length > 1)
         for key in parsed_query.keys
           if key != "program"
-            puts "----", parsed_query[key]
-            filtered_artists = filtered_artists.select{|artist| (artist[key] == parsed_query[key])}
+            filtered_artists = filtered_artists.select{|artist| (artist[key] == parsed_query[key][0])}
           end
         end
       end

--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -30,20 +30,37 @@ class Api::ArtistsController < ApplicationController
 
   def filtered_artists
     parsed_query = CGI.parse(params[:search_params])
-    if "program".in?(parsed_query.keys)
-      filtered_artists = Artist.all.select{|artist| ((artist.program & parsed_query.values[0]).length > 0) }
-      if (parsed_query.keys.length > 1)
-        for key in parsed_query.keys
-          if key != "program"
-            filtered_artists = filtered_artists.select{|artist| (artist[key] == parsed_query[key][0])}
-          end
+    all_artists = Artist.all
+    filtered_program_artists = Artist.all
+    filtered_artists = Artist.all
+    filter_categories = parsed_query.keys
+    for category in filter_categories
+      if category == "program"
+        query_programs = parsed_query["program"]
+        filtered_program_artists = Artist.where(["program @> ?", "{#{query_programs[0]}}"])
+        for programs in parsed_query["program"][1..query_programs.length]
+          filtered_program_artists = filtered_program_artists.or(all_artists.where(["program @> ?", "{#{programs}}"]))
+        end
+      else
+        filters = parsed_query[category]
+        filtered_artists = filtered_artists.where(["#{category}=?", Artist.degrees[filters[0]]])
+        for filter in filters[1..filters.length]
+          filtered_artists = filtered_artists.or(all_artists.where(["#{category}=?", Artist.degrees[filter]]))
         end
       end
-    else
-      filtered_artists = params[:search_params] == "" ?  Artist.all : Artist.where(parsed_query)
     end
-    render json: filtered_artists,
-      each_serializer: ArtistSerializer
+    filtered_artists = filtered_artists.merge(filtered_program_artists)
+    
+    filtered_artists = current_admin ? 
+      filtered_artists : 
+      filtered_artists.joins(:works).group('artists.id, works.hidden').where("works.hidden=false").where("artists.hidden=false")
+    filtered_artists_page = filtered_artists.page(params[:page])
+    artist_count = filtered_artists.length
+    render json: {
+      artists: ActiveModel::Serializer::CollectionSerializer.new(filtered_artists_page, each_serializer: ArtistSerializer),
+      artist_count: artist_count,
+      per_page: Artist.default_per_page
+    }
   end
 
   def update

--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -32,8 +32,13 @@ class Api::ArtistsController < ApplicationController
     parsed_query = CGI.parse(params[:search_params])
     if "program".in?(parsed_query.keys)
       filtered_artists = Artist.all.select{|artist| ((artist.program & parsed_query.values[0]).length > 0) }
-      if (parsed_query.keys.length > 1) && (("degree").in?(parsed_query.keys))
-        filtered_artists = filtered_artists.select{|artist| (artist.degree == parsed_query.values[1][0])}
+      if (parsed_query.keys.length > 1)
+        for key in parsed_query.keys
+          if key != "program"
+            puts "----", parsed_query[key]
+            filtered_artists = filtered_artists.select{|artist| (artist[key] == parsed_query[key])}
+          end
+        end
       end
     else
       filtered_artists = params[:search_params] == "" ?  Artist.all : Artist.where(parsed_query)

--- a/app/javascript/components/artists/ArtistProfile.jsx
+++ b/app/javascript/components/artists/ArtistProfile.jsx
@@ -148,7 +148,7 @@ class ArtistProfile extends React.Component {
       "Description": Boolean(artist.description),
       "Featured work": Boolean(artist.featured_work_id),
       "Media": Boolean(artist.media),
-      "Program": Boolean(artist.program),
+      "Program": Boolean(artist.program.length > 0),
       "Year": Boolean(artist.year)
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,7 +943,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.x, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -5379,13 +5379,6 @@ raw-body@2.3.3:
     http-errors "1.6.3"
     iconv-lite "0.4.23"
     unpipe "1.0.0"
-
-rc-touchable@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/rc-touchable/-/rc-touchable-1.3.1.tgz#fe6200ff8ef76db56971498b50b15162e91ad4ca"
-  integrity sha512-A52MNEZV3+9w8q+jSXM6sWutyHhsCz/q2hdBHDN75KJpAmhBiy8QrO75u6qzlgaHTXtmKphITciuUcdvPdpKMQ==
-  dependencies:
-    babel-runtime "6.x"
 
 rc@^1.2.7:
   version "1.2.8"


### PR DESCRIPTION
## Fixed Program Filters
Program filters in All Artists tab was broken because of switch from enums to array of strings. Modified logic to check for common values between artist programs and program query values to display all artists with at least one program specified in filters.

Also includes a fix for progress banner in Artist Profile to check for empty program array.

### Related PRs
None.

### Migrations
None.

### Tests Performed, Edge Cases
Tested with combination of programs and degrees in filters

### Screenshots
![Screen Shot 2019-05-04 at 4 54 00 PM](https://user-images.githubusercontent.com/21699109/57186068-78f0c580-6e8d-11e9-8cea-605908e16d7d.png)

CC: @by-co
